### PR TITLE
feat: update parent products index when child is changed

### DIFF
--- a/Model/Mview/View/StagingSubscription.php
+++ b/Model/Mview/View/StagingSubscription.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Copyright (c) 2023 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Model\Mview\View;
+
+use Magento\Framework\DB\Ddl\Trigger;
+use Magento\Framework\Mview\ViewInterface;
+
+class StagingSubscription extends \Magento\CatalogStaging\Model\Mview\View\Attribute\Subscription
+{
+
+    /**
+     * @inheritDoc
+     */
+    protected function buildStatement(string $event, ViewInterface $view): string
+    {
+        $triggerBody = parent::buildStatement($event, $view);
+        $bodyParts = explode(PHP_EOL, $triggerBody);
+        $preStatement = array_shift($bodyParts);
+        $stringCondition = 'SET @entity_id';
+        $preStatement = (substr((string)$preStatement, 0, strlen($stringCondition)) == $stringCondition)
+            ? $preStatement
+            : '';
+
+        if (!$preStatement) {
+            return $preStatement;
+        }
+
+        switch ($event) {
+            case Trigger::EVENT_INSERT:
+            case Trigger::EVENT_UPDATE:
+                $eventType = 'NEW';
+                break;
+            case Trigger::EVENT_DELETE:
+                $eventType = 'OLD';
+                break;
+            default:
+                return $triggerBody;
+        }
+
+        $preStatement = $this->buildEntityIdStatementByEventType($eventType, $view);
+
+        return $preStatement . implode(PHP_EOL, $bodyParts);
+    }
+
+    /**
+     * Build trigger body
+     *
+     * @param string $eventType
+     * @param ViewInterface $view
+     * @return string
+     */
+    private function buildEntityIdStatementByEventType(string $eventType, ViewInterface $view): string
+    {
+        return vsprintf(
+                'SET @entity_id = (SELECT %1$s FROM %2$s WHERE %3$s = %4$s.%5$s);',
+                [
+                    $this->connection->quoteIdentifier(
+                        $this->entityMetadata->getIdentifierField()
+                    ),
+                    $this->connection->quoteIdentifier(
+                        $this->resource->getTableName($this->entityMetadata->getEntityTable())
+                    ),
+                    $this->connection->quoteIdentifier(
+                        $this->entityMetadata->getLinkField()
+                    ),
+                    $eventType,
+                    $this->connection->quoteIdentifier($this->getSubscriptionColumn($view))
+                ]
+            ) . PHP_EOL;
+    }
+
+    /**
+     * Returns subscription column name by view
+     *
+     * @param ViewInterface $view
+     * @return string
+     */
+    private function getSubscriptionColumn(ViewInterface $view): string
+    {
+        $subscriptions = $view->getSubscriptions();
+        if (!isset($subscriptions[$this->getTableName()]['column'])) {
+            throw new \RuntimeException(sprintf('Column name for view with id "%s" doesn\'t exist', $view->getId()));
+        }
+
+        return $subscriptions[$this->getTableName()]['column'];
+    }
+}

--- a/Model/Product.php
+++ b/Model/Product.php
@@ -15,11 +15,10 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model;
 
-use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\Product\Type;
 use Magento\Catalog\Model\Product\Type\AbstractType;
 use Magento\Catalog\Model\ProductFactory;
-use Magento\Catalog\Model\Product as ProductModel;
+use Magento\CatalogSearch\Model\ResourceModel\Fulltext as FulltextResource;
 
 class Product
 {
@@ -39,16 +38,25 @@ class Product
     private $productType;
 
     /**
+     * @var FulltextResource
+     */
+    private $fulltextResource;
+
+    /**
      * Product constructor.
+     *
      * @param ProductFactory $productFactory
      * @param Type $productType
+     * @param FulltextResource $fulltextResource
      */
     public function __construct(
         ProductFactory $productFactory,
-        Type $productType
+        Type $productType,
+        FulltextResource $fulltextResource
     ) {
         $this->productFactory = $productFactory;
         $this->productType = $productType;
+        $this->fulltextResource = $fulltextResource;
     }
 
     /**
@@ -73,11 +81,6 @@ class Product
      */
     public function getParentProductIds(array $ids)
     {
-        $parentIds = [];
-        foreach ($this->getCompositeTypes() as $typeInstance) {
-            $parentIds = array_merge($parentIds, $typeInstance->getParentIdsByChild($ids));
-        }
-
-        return $parentIds;
+        return $this->fulltextResource->getRelationsByChild($ids);
     }
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1080,6 +1080,21 @@
         </arguments>
     </type>
 
+    <type name="Magento\CatalogStaging\Model\Mview\View\SubscriptionFactory">
+        <arguments>
+            <argument name="subscriptionModels" xsi:type="array">
+                <item name="catalog_product_relation" xsi:type="string">
+                    HawkSearch\EsIndexing\Model\Mview\StagedProductAttributeSubscription
+                </item>
+            </argument>
+        </arguments>
+    </type>
+    <virtualType name="HawkSearch\EsIndexing\Model\Mview\StagedProductAttributeSubscription"
+                 type="HawkSearch\EsIndexing\Model\Mview\View\StagingSubscription">
+        <arguments>
+            <argument name="entityInterface" xsi:type="string">Magento\Catalog\Api\Data\ProductInterface</argument>
+        </arguments>
+    </virtualType>
 
     <!-- END Types -->
 

--- a/etc/indexer.xml
+++ b/etc/indexer.xml
@@ -21,6 +21,9 @@
         </description>
         <dependencies>
             <indexer id="hawksearch_entities" />
+            <indexer id="catalog_category_product" />
+            <indexer id="cataloginventory_stock" />
+            <indexer id="catalog_product_price" />
         </dependencies>
     </indexer>
     <indexer id="hawksearch_content_pages" view_id="hawksearch_content_pages"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -17,7 +17,7 @@
     <module name="HawkSearch_EsIndexing">
         <sequence>
             <module name="HawkSearch_Connector"/>
-            <module name="Magento_Catalog"/>
+            <module name="Magento_CatalogStaging"/>
             <module name="Magento_Review"/>
             <module name="Magento_Indexer"/>
             <module name="Magento_AsynchronousOperations"/>

--- a/etc/mview.xml
+++ b/etc/mview.xml
@@ -22,12 +22,12 @@
             <table name="catalog_product_entity_decimal" entity_column="entity_id" />
             <table name="catalog_product_entity_gallery" entity_column="entity_id" />
             <table name="catalog_product_entity_int" entity_column="entity_id" />
-            <table name="catalog_product_entity_media_gallery" entity_column="value_id" />
             <table name="catalog_product_entity_media_gallery_value" entity_column="entity_id" />
             <table name="catalog_product_entity_text" entity_column="entity_id" />
             <table name="catalog_product_entity_tier_price" entity_column="entity_id" />
             <table name="catalog_product_entity_varchar" entity_column="entity_id" />
             <table name="catalog_category_product" entity_column="product_id" />
+            <table name="catalog_product_relation" entity_column="parent_id"/>
         </subscriptions>
     </view>
     <view id="hawksearch_content_pages" class="HawkSearch\EsIndexing\Model\Indexer\ContentPage" group="indexer">


### PR DESCRIPTION
When child product is updated/removed then all parents are updated in the index.
When child product is assigned to parent product then parent one is updated in the index.
The [following extension](https://github.com/hawksearch/index-by-schedule-magento2) is required to have 
some product relations to be updated when product is removed and HawkSearch indexers are
in "By Schedule" mode


Refs: #HC-1403