### PR TITLE
fix: unknown column started_at

### DIFF
--- a/Model/ResourceModel/AsynchronousOperations/Operation.php
+++ b/Model/ResourceModel/AsynchronousOperations/Operation.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright (c) 2023 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Model\ResourceModel\AsynchronousOperations;
+
+use Magento\AsynchronousOperations\Model\ResourceModel\Operation as OperationResource;
+
+class Operation
+{
+    private OperationResource $operationResource;
+
+    /**
+     * @param OperationResource $operationResource
+     */
+    public function __construct(OperationResource $operationResource)
+    {
+        $this->operationResource = $operationResource;
+    }
+
+    /**
+     * @return bool
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function isStartedAtColumnExists()
+    {
+        return $this->operationResource->getConnection()->tableColumnExists(
+            $this->operationResource->getMainTable(),
+            'started_at'
+        );
+    }
+}

--- a/Ui/Component/Listing/Column/StartTime.php
+++ b/Ui/Component/Listing/Column/StartTime.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Copyright (c) 2023 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Ui\Component\Listing\Column;
+
+use HawkSearch\EsIndexing\Model\ResourceModel\AsynchronousOperations\Operation;
+use Magento\Framework\Locale\Bundle\DataBundle;
+use Magento\Framework\Locale\ResolverInterface;
+use Magento\Framework\Stdlib\BooleanUtils;
+use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
+use Magento\Framework\View\Element\UiComponent\ContextInterface;
+use Magento\Framework\View\Element\UiComponentFactory;
+use Magento\Ui\Component\Listing\Columns\Date;
+
+class StartTime extends Date
+{
+    /**
+     * @var Operation
+     */
+    private $operation;
+
+    /**
+     * @param ContextInterface $context
+     * @param UiComponentFactory $uiComponentFactory
+     * @param TimezoneInterface $timezone
+     * @param BooleanUtils $booleanUtils
+     * @param Operation $operation
+     * @param array $components
+     * @param array $data
+     * @param ResolverInterface|null $localeResolver
+     * @param DataBundle|null $dataBundle
+     */
+    public function __construct(
+        ContextInterface $context,
+        UiComponentFactory $uiComponentFactory,
+        TimezoneInterface $timezone,
+        BooleanUtils $booleanUtils,
+        Operation $operation,
+        array $components = [],
+        array $data = [],
+        ResolverInterface $localeResolver = null,
+        DataBundle $dataBundle = null
+    ) {
+        $this->operation = $operation;
+        parent::__construct(
+            $context,
+            $uiComponentFactory,
+            $timezone,
+            $booleanUtils,
+            $components,
+            $data,
+            $localeResolver,
+            $dataBundle
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function prepare()
+    {
+        parent::prepare();
+
+        $config = (array)$this->getData('config');
+        if (!$this->operation->isStartedAtColumnExists()) {
+            $config['componentDisabled'] = true;
+        }
+        $this->setData('config', $config);
+    }
+}

--- a/view/adminhtml/ui_component/hawksearch_bulk_listing.xml
+++ b/view/adminhtml/ui_component/hawksearch_bulk_listing.xml
@@ -80,7 +80,7 @@
                 <label translate="true">Start Time</label>
             </settings>
         </column>
-        <column name="last_time" class="Magento\Ui\Component\Listing\Columns\Date" component="Magento_Ui/js/grid/columns/date" sortOrder="40">
+        <column name="last_time" class="HawkSearch\EsIndexing\Ui\Component\Listing\Column\StartTime" component="Magento_Ui/js/grid/columns/date" sortOrder="40">
             <settings>
                 <filter>dateRange</filter>
                 <dataType>date</dataType>


### PR DESCRIPTION
On Magento Open Source and Adobe Commerce version 2.4.3  and less was no column ‘started_at’ in the  magento_operation table. As a result, an error occurred on the page Indexing Bulks

Fixes HC-1472