### PR TITLE
feat: disable indexing by default

### DIFF
--- a/Model/Config/Indexing.php
+++ b/Model/Config/Indexing.php
@@ -27,6 +27,8 @@ class Indexing extends ConfigProvider
     public const CONFIG_PRODUCTS_INCLUDE_CATEGORIES_HIERARCHY = 'products_include_categories_hierarchy';
     /**#@-*/
 
+    public const ENABLE_INDEXING_DEFAULT = 0;
+
     /**
      * Return items batch size for indexing job single operation
      * @param null|int|string $store

--- a/Plugin/Store/StoreViewDisableIndexingPlugin.php
+++ b/Plugin/Store/StoreViewDisableIndexingPlugin.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * Copyright (c) 2023 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Plugin\Store;
+
+use HawkSearch\EsIndexing\Model\Config\Indexing as IndexingConfig;
+use Magento\Framework\App\Config\ReinitableConfigInterface;
+use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\Framework\Model\AbstractModel;
+use Magento\Store\Model\ResourceModel\Store as StoreResourceModel;
+use Magento\Store\Model\ScopeInterface;
+
+class StoreViewDisableIndexingPlugin
+{
+    /**
+     * @var IndexingConfig
+     */
+    private $indexingConfig;
+
+    /**
+     * @var WriterInterface
+     */
+    private $configWriter;
+
+    /**
+     * @var ReinitableConfigInterface
+     */
+    private $reinitableConfig;
+
+    /**
+     * @param IndexingConfig $indexingConfig
+     * @param WriterInterface $configWriter
+     * @param ReinitableConfigInterface $reinitableConfig
+     */
+    public function __construct(
+        IndexingConfig $indexingConfig,
+        WriterInterface $configWriter,
+        ReinitableConfigInterface $reinitableConfig
+    ) {
+        $this->indexingConfig = $indexingConfig;
+        $this->configWriter = $configWriter;
+        $this->reinitableConfig = $reinitableConfig;
+    }
+
+    /**
+     * Disable indexing for new store view
+     *
+     * @param StoreResourceModel $subject
+     * @param StoreResourceModel $result
+     * @param AbstractModel $store
+     * @return StoreResourceModel
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function afterSave(StoreResourceModel $subject, StoreResourceModel $result, AbstractModel $store)
+    {
+        if ($store->isObjectNew() && $this->indexingConfig->isIndexingEnabled($store)) {
+            $this->configWriter->save(
+                $this->indexingConfig->getPath(IndexingConfig::CONFIG_ENABLE_INDEXING),
+                IndexingConfig::ENABLE_INDEXING_DEFAULT,
+                ScopeInterface::SCOPE_STORES,
+                $store->getId()
+            );
+            $this->reinitableConfig->reinit();
+        }
+
+        return $result;
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -26,9 +26,13 @@
             <label>Indexing</label>
             <tab>hawksearch</tab>
             <resource>HawkSearch_EsIndexing::config</resource>
-            <group id="indexing" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+            <group id="indexing" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Indexing</label>
-                <field id="enable_indexing" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                <comment><![CDATA[
+                    To <b>Eenable Indexing</b> please switch to Store View configuration scope
+                    ]]>
+                </comment>
+                <field id="enable_indexing" translate="label comment" type="select" sortOrder="10" showInDefault="0" showInWebsite="0" showInStore="1">
                     <label>Enable Indexing</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>Enables indexing of your data by Hawksearch.</comment>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -16,6 +16,7 @@
     <default>
         <hawksearch_indexing_settings>
             <indexing>
+                <enable_indexing>0</enable_indexing>
                 <items_batch_size>125</items_batch_size>
             </indexing>
         </hawksearch_indexing_settings>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1130,6 +1130,8 @@
     <type name="Magento\Store\Model\ResourceModel\Store">
         <plugin name="hawksearchStoreView"
                 type="HawkSearch\EsIndexing\Plugin\Store\StoreViewPlugin"/>
+        <plugin name="hawksearchStoreViewDisableIndexing"
+                type="HawkSearch\EsIndexing\Plugin\Store\StoreViewDisableIndexingPlugin"/>
     </type>
     <type name="Magento\Store\Model\ResourceModel\Group">
         <plugin name="hawksearchStoreGroup"


### PR DESCRIPTION
- `Enable Indexing` config now only available on Store View scope.
- `Enable Indexing` config default value  is changed to “No“.
- Indexing is disable by default for a new created store.

Refs: HC-1449