### PR TITLE
feat: product visibility attribute indexing logic changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 See tasks currently in development on [Unreleased] changes page.
 
+## 0.7.0 - [Unreleased]
+
+### DEPRECATIONS
+
+* Class changes:
+  - HawkSearch\EsIndexing\Model\ContentPage\Attribute\Handler\Url is deprecated,
+    use HawkSearch\EsIndexing\Model\ContentPage\Field\Handler\Url
+  - HawkSearch\EsIndexing\Model\Hierarchy\Attribute\Handler\HierarchyId is deprecated,
+    use HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\HierarchyId
+  - HawkSearch\EsIndexing\Model\Hierarchy\Attribute\Handler\IsActive is deprecated,
+    use HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\IsActive
+  - HawkSearch\EsIndexing\Model\Hierarchy\Attribute\Handler\Name is deprecated,
+    use HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\Name
+  - HawkSearch\EsIndexing\Model\Hierarchy\Attribute\Handler\ParentHierarchyId is deprecated,
+    use HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\ParentHierarchyId
+  - HawkSearch\EsIndexing\Model\Indexing\AttributeHandler\Composite is deprecated,
+    use HawkSearch\EsIndexing\Model\Indexing\FieldHandler\Composite
+  - HawkSearch\EsIndexing\Model\Indexing\AttributeHandler\DataObjectHandler is deprecated,
+    use HawkSearch\EsIndexing\Model\Indexing\FieldHandler\DataObjectHandler
+  - HawkSearch\EsIndexing\Model\LandingPage\Attribute\Handler\CustomSortList is deprecated,
+    use HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\CustomSortList
+  - HawkSearch\EsIndexing\Model\LandingPage\Attribute\Handler\CustomUrl is deprecated,
+    use HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\CustomUrl
+  - HawkSearch\EsIndexing\Model\LandingPage\Attribute\Handler\DefaultHandler is deprecated,
+    use HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\DefaultHandler
+  - HawkSearch\EsIndexing\Model\LandingPage\Attribute\Handler\NarrowXml is deprecated,
+    use HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\NarrowXml
+  - HawkSearch\EsIndexing\Model\Product\Attribute\Handler\Category is deprecated,
+    use HawkSearch\EsIndexing\Model\Product\Field\Handler\Category
+  - HawkSearch\EsIndexing\Model\Product\Attribute\Handler\Composite is deprecated,
+    use HawkSearch\EsIndexing\Model\Product\Field\Handler\Composite
+  - HawkSearch\EsIndexing\Model\Product\Attribute\Handler\DefaultHandler is deprecated,
+    use HawkSearch\EsIndexing\Model\Product\Field\Handler\DefaultHandler
+  - HawkSearch\EsIndexing\Model\Product\Attribute\Handler\ImageUrl is deprecated,
+    use HawkSearch\EsIndexing\Model\Product\Field\Handler\ImageUrl
+  - HawkSearch\EsIndexing\Model\Product\Attribute\Handler\Url is deprecated,
+    use HawkSearch\EsIndexing\Model\Product\Field\Handler\Url
+  - Parameter $attributeHandler is deprecated in method
+    HawkSearch\EsIndexing\Model\Indexing\EntityType::__construct(),
+    use $fieldHandler
+  - HawkSearch\EsIndexing\Model\Indexing\EntityType\EntityTypeAbstract::getAttributeHandler()
+    is deprecated,
+    use HawkSearch\EsIndexing\Model\Indexing\EntityType\EntityTypeAbstract::getFieldHandler()
+
+* Interface changes:
+  - HawkSearch\EsIndexing\Model\Indexing\AttributeHandlerInterface is
+    deprecated,
+    use HawkSearch\EsIndexing\Model\Indexing\FieldHandlerInterface
+  - HawkSearch\EsIndexing\Model\Indexing\EntityTypeInterface::getAttributeHandler()
+    is deprecated,
+    use HawkSearch\EsIndexing\Model\Indexing\EntityTypeInterface::getFieldHandler()
+
+* Di changes:
+  - HawkSearch\EsIndexing\Model\Hierarchy\Attribute\Handler\Composite virtual type is deprecated
+    use HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\Composite
+  - HawkSearch\EsIndexing\Model\ContentPage\Attribute\Handler\Composite virtual type is deprecated
+    use HawkSearch\EsIndexing\Model\ContentPage\Field\Handler\Composite
+  - HawkSearch\EsIndexing\Model\LandingPage\Attribute\Handler\Composite virtual type is deprecated
+    use HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\Composite
+
 ## [0.6.4] - 2024-05-08
 
 ## FIXES
@@ -34,7 +94,7 @@ See tasks currently in development on [Unreleased] changes page.
 
 ## [0.6.3] - 2024-04-25
 
-## FIXES
+### FIXES
 
 * __fix: minicart not updated after adding product to cart__ ([#57](https://github.com/hawksearch/esindexing-magento-2/pull/57))
 
@@ -42,7 +102,7 @@ See tasks currently in development on [Unreleased] changes page.
 
 ## [0.6.2] - 2024-03-20
 
-## FIXES
+### FIXES
 
 * __fix: sql error on indexing product with no categories__ ([9989ea6](https://github.com/hawksearch/esindexing-magento-2/commit/9989ea64562a190ee80ea03395ad7b52f0ce6bea))
   
@@ -51,7 +111,7 @@ See tasks currently in development on [Unreleased] changes page.
 
 ## [0.6.1] - 2024-03-05
 
-## FIXES
+### FIXES
 
 * __fix: popular searches and content matches not clickable__ ([#51](https://github.com/hawksearch/esindexing-magento-2/pull/51))
   
@@ -77,7 +137,7 @@ See tasks currently in development on [Unreleased] changes page.
 
 ## [0.6.0] - 2024-02-09
 
-## FEATURES
+### FEATURES
 
 * __feat: add price to suggestion item (autocomplete)__ ([#47](https://github.com/hawksearch/esindexing-magento-2/pull/47))
   
@@ -100,7 +160,7 @@ See tasks currently in development on [Unreleased] changes page.
 
   Ref: HC-1204
 
-## FIXES
+### FIXES
 
 * __fix: zero price for complex products__ ([#47](https://github.com/hawksearch/esindexing-magento-2/pull/47))
   
@@ -118,13 +178,13 @@ See tasks currently in development on [Unreleased] changes page.
 
 ## [0.5.1] - 2024-01-18
 
-## FIXES
+### FIXES
 
 __fix: minimal compatible version of connector package is 2.8.0__ ([#45](https://github.com/hawksearch/esindexing-magento-2/pull/45))
 
 ## [0.5.0] - 2024-01-18
 
-## FEATURES
+### FEATURES
 
 * __feat: add tracking for add2cart and sale events__ ([#34](https://github.com/hawksearch/esindexing-magento-2/pull/34))
 
@@ -162,7 +222,7 @@ __fix: minimal compatible version of connector package is 2.8.0__ ([#45](https:/
 
   Refs HC-1447
 
-## FIXES
+### FIXES
 
 * __fix: cannot read properties of undefined in getID function__ ([#26](https://github.com/hawksearch/esindexing-magento-2/pull/26))
 
@@ -191,7 +251,7 @@ __fix: minimal compatible version of connector package is 2.8.0__ ([#45](https:/
 
 ## [0.4.2] - 2023-10-12
 
-## FIXES
+### FIXES
 * __fix: remove hierarchyRebuild message form the queue__ ([c480c34](https://github.com/hawksearch/esindexing-magento-2/commit/c480c343825fc6f8a68b241366cf34df594ca024))
 
   Ref ([#HC-1494](https://bridgeline.atlassian.net/browse/HC-1494))
@@ -202,7 +262,7 @@ __fix: minimal compatible version of connector package is 2.8.0__ ([#45](https:/
 
 ## [0.4.1] - 2023-09-27
 
-## FIXES
+### FIXES
 * __fix: remove dependency on CatalogStaging module__ ([f755f93](https://github.com/hawksearch/esindexing-magento-2/commit/f755f9310c551984fa7330b9a1a655bc4ac16f0c))
   
   Unable to install the extension because of compatibility issue:
@@ -232,13 +292,13 @@ __fix: minimal compatible version of connector package is 2.8.0__ ([#45](https:/
 
 ## [0.4.0] - 2023-07-07
 
-## FEATURES
+### FEATURES
 - update parent products index when child is changed ([48019c6](https://github.com/hawksearch/esindexing-magento-2/commit/48019c6b78330033dbd59c7cc971a6bb6c518c81))
   When child product is updated/removed then all parents are updated in the index.
   When child product is assigned to parent product then parent one is updated in the index.
   Refs: [#HC-1403](https://bridgeline.atlassian.net/browse/HC-1403)
 
-## FIXES
+### FIXES
 - duplicate async operations with the same ID in collection ([163daf5](https://github.com/hawksearch/esindexing-magento-2/commit/163daf5b25894bc9fd903b267cfc83c60198c322))
 - invalid array index because of nonexistent category when indexing ([ed3253b](https://github.com/hawksearch/esindexing-magento-2/commit/ed3253b00786c27ed98687bb48cb15cc4bf037ac))
   Refs: [#HC-1437](https://bridgeline.atlassian.net/browse/HC-1437)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,264 @@
+## Backward compatibility policy
+
+During active product development and feature improvement we make changes in minor or patch releases. From time to time,
+some classes, interfaces and methods require to get updates in its structure and signature. We should perform any 
+modification and to not break code that developers may be relying on. We follow the strategy of [Semantic Versioning](https://semver.org/) 
+and develop all minor releases with a backward compatibility (BC) in mind.
+
+In fact, almost every change can break an application. For example, if we add a new public or protected method to a class,
+this may break an application in case, when someone has already added the same method but with a different signature 
+in derived class. 
+
+The goal of this document is to give a guidance for core and third party developers how to safely make changes 
+in the existing codebase with the minimal efforts. Follow the rules and best practices for backward compatible 
+development together with HawkSearch core team.
+
+### Deprecation
+
+HawkSearch Core development policy states that public API will not be changed unexpectedly. Whenever a new API is added, 
+the old API is deprecated. Follow [Removal of deprecated code](#removal-of-deprecated-code) section for learning the terms 
+when deprecation is still available.
+
+#### Deprecation steps
+
+Deprecating procedure consists of these steps:
+
+1. Add `@deprecated` PHPdoc and follow it up with an explanation.
+2. Use the `@see` tag to suggest a replacement. If `@see` tag can't be used suggest a replacement in deprecation message.
+3. Keep previous code working.
+4. Trigger a deprecation message `@trigger_error('...', E_USER_DEPRECATED)` in deprecated methods/classes 
+   to notify developers about a deprecated functionality. The `@` suppression should be used in most cases 
+   so that we can customize the error handling and avoid flooding logs on production.
+5. Remove the code in the next major version or in accordance with the [deprecation removal schedule](#removal-of-deprecated-code).
+
+#### Document deprecations
+
+All deprecations should be recorded within `CHANGELOG.md` file under _DEPRECATIONS_ section for each minor release.
+Entries to the _DEPRECATIONS_ section are made at the same time as the code is changed. During review phase the patch 
+changes with deprecations should not pass a review if deprecations are not documented. Bellow is an example of
+_DEPRECATIONS_ section in `CHANGELOG.md` file:
+
+```markdown
+## [0.7.0] - 2024-04-18
+
+### DEPRECATIONS
+
+* Class changes:
+    - Model\ContentPage\Attribute\Handler\Url is deprecated,
+      use Model\ContentPage\Field\Handler\Url
+
+* Interface changes:
+    - HawkSearch\EsIndexing\Model\Indexing\AttributeHandlerInterface is
+      deprecated,
+      use HawkSearch\EsIndexing\Model\Indexing\FieldHandlerInterface
+
+* Di changes:
+    - HawkSearch\EsIndexing\Model\Hierarchy\Attribute\Handler\Composite virtual type is deprecated
+      use HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\Composite
+```
+
+### Deprecating classes/interfaces
+
+- Add a `@deprecated` annotation to the class/interface doc comment and all methods, properties and constants
+  doc comment so an IDE can highlight them as deprecated.
+- If class/interface is deprecated in favour of a new API use `@see` annotation in class/interface linking to a new
+  API which is used instead.
+- Add a `@deprecated` phpdoc annotation and `@trigger_error('...', E_USER_DEPRECATED)` to the constructor. 
+  If there is no constructor, add one and ensure it calls the parent constructor.
+- Add `@trigger_error('...', E_USER_DEPRECATED)` before the interface/class declaration so that the deprecation error
+  will be triggered in case of static class/interface usage.
+- Extend an old class/interface from the new one if it logically makes sense. In this case the new API which has a 
+  dependency on a new class/interface can still accept old interface instances. 
+
+Deprecating Interface example:
+```php
+<?php
+
+namespace HawkSearch\EsIndexing\Model\Indexing;
+
+\HawkSearch\Connector\Compatibility\PublicContractDeprecation::triggerDeprecationMessage(
+    AttributeHandlerInterface::class,
+    '0.7.0',
+    FieldHandlerInterface::class,
+    'In favour of a new Field Handlers logic.'
+);
+
+/**
+ * @deprecated 0.7.0 in favour of a new Field Handlers logic
+ * @see FieldHandlerInterface 
+ */
+interface AttributeHandlerInterface extends FieldHandlerInterface
+{
+    // Old public interface methods have been moved to FieldHandlerInterface
+}
+```
+
+Deprecating Class example:
+```php
+<?php
+
+namespace HawkSearch\EsIndexing;
+
+/**
+ * @deprecated 0.7.0 because of removed logic
+ */
+class OldConcreteClass extends BaseClass
+{
+    /**
+     * @var string
+     * @deprecated 0.7.0 because of removed logic
+     */
+    protected $property;
+
+    /**
+     * @deprecated 0.7.0 because of removed logic
+     */
+    public function __construct()
+    {
+        @trigger_error(__CLASS__ .' is deprecated in 0.7.0. Please adopt your code to a new changes', E_USER_DEPRECATED);
+        parent::__construct();
+    }
+    
+    /**
+     * @deprecated 0.7.0  because of removed logic
+     * @return void
+     */
+    public function addPublicAction() 
+    {
+        // ... method logic
+    }
+    
+    /**
+     * @deprecated 0.7.0  because of removed logic
+     * @return void
+     */
+    protected function addSomeProtectedData() 
+    {
+        // ... method logic
+    }
+}
+```
+
+### Deprecating methods
+
+- Add `@deprecated` to the docblock for public and protected methods.
+- Add `@trigger_error('...', E_USER_DEPRECATED)` at the top of the method.
+- Continue returning the same results from the method if possible, so the old functionality is preserved.
+
+```php
+<?php
+
+/**
+ * @deprecated 0.7.0 because of unused logic
+ * @return void
+ */
+public function addPublicAction() 
+{
+    @trigger_error(__METHOD__ .' is deprecated in 0.7.0. Please adopt your code to a new changes', E_USER_DEPRECATED);
+    // ... method logic
+}
+```
+
+### Adding new methods to interfaces and abstract classes
+
+Adding a new method to an interface or an abstract method to a base abstract class is a breaking change.
+Depending on the scenario the interface/abstract class is used in concrete application there are three options available 
+to overcome the breaking change. 
+
+#### Introduce an existing interface extension
+
+This option doesn't refer to deprecation and will not lead to a breaking change in the future because it is a kind of 
+optional logic concrete class can get. This technique can be achieved in the following steps:
+- Create a new interface with a new method instead of introducing a method to an existing interface.
+- All concrete classes which want to get a new logic introduced in the new method have to implement an extended 
+  interface along with the old one.
+
+Example:
+```php
+<?php
+
+/**
+ * This is the interface we want to extend with a new method
+ */
+interface OldInterface
+{
+    public function call();
+}
+
+/**
+ * This is the extension of OldInterface via callExtended() method
+ */
+interface ExtendedOldInterface
+{
+    /**
+     * This is a new method
+     */
+    public function callExtended();
+}
+
+class ConcreteClass implements OldInterface, ExtendedOldInterface
+{
+    public function call()
+    {
+        // implementation of call() method
+    }
+    
+    public function callExtended()
+    {
+        // implementation of a new callExtended() method
+    }
+}
+```
+
+#### Fully deprecate an existing interface
+
+Sometimes it is reasonable to deprecate the whole interface and create a new one with a new method. Reference 
+[Deprecating classes/interfaces](#deprecating-classesinterfaces) for this option.
+
+#### Add a new method to an existing interface
+
+This is a common scenario for cases when interface referencing a DB entity or similar. We don't want to create the 
+interface extension or fully deprecate the current interface. The steps for this option are the following:
+
+- Add `@method` annotation to the interface doc comment
+- Implement a new method in all classes implementing the interface
+- Safely call a new method in all places where interface is used: check if new method exists in the class object using 
+  `method_exists()` function and call it, call an old method otherwise.
+
+### Deprecating properties
+
+- Add `@deprecated` annotation tag to the property docblock.
+- Continue storing the value in the property, so the old functionality is preserved.
+
+
+### Adding a constructor argument
+
+### Removing a constructor argument
+
+### Adding a new method argument
+
+#### public methods
+#### protected methods
+
+### Removing a method argument
+
+### Modifying the default values of optional arguments in public and protected methods
+
+### Changing scope: public, protected, private
+
+### Converting a method scope from public to protected
+
+### Converting a public property to protected
+
+
+### Removing, renaming, or changing the type of event arguments
+
+### Deprecations in Javascript
+
+
+### Removal of deprecated code
+
+**Before the first major release 1.0.0**, all deprecated code will not be removed the next 2 minor releases or until a major release. 
+For example, if deprecation is announced in v0.8.0 it will be preserved until v0.10.0 and will be removed in v0.11.0 or in v1.0.0, 
+depending on what happens first.  
+**After the release 1.0.0**, all deprecated code will be removed on next major release.

--- a/Console/Command/RetryBulk.php
+++ b/Console/Command/RetryBulk.php
@@ -149,7 +149,7 @@ class RetryBulk extends Command
                 $output->writeln(__('No operations found to retry'));
             }
         } catch (\Exception $exception) {
-            $output->writeln(__('An error occurred: %1', $exception->getMessage()));
+            $output->writeln(__('<error>An error occurred: %1</error>', $exception->getMessage()));
             return 1;
         }
         return 0;

--- a/Model/ContentPage/Attribute/Handler/Url.php
+++ b/Model/ContentPage/Attribute/Handler/Url.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2022 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -14,39 +14,19 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\ContentPage\Attribute\Handler;
 
-use HawkSearch\EsIndexing\Model\Indexing\AttributeHandlerInterface;
-use Magento\Cms\Api\Data\PageInterface;
-use Magento\Framework\DataObject;
-use Magento\Framework\Exception\NoSuchEntityException;
-use Magento\Store\Model\StoreManagerInterface;
+use HawkSearch\Connector\Compatibility\PublicContractDeprecation;
 
-class Url implements AttributeHandlerInterface
+PublicContractDeprecation::triggerClassDeprecationMessage(
+    Url::class,
+    '0.7.0',
+    \HawkSearch\EsIndexing\Model\ContentPage\Field\Handler\Url::class,
+    'In favour of a new Field Handlers logic.'
+);
+
+/**
+ * @deprecated 0.7.0 In favour of a new Field Handlers logic
+ * @see \HawkSearch\EsIndexing\Model\ContentPage\Field\Handler\Url
+ */
+class Url extends \HawkSearch\EsIndexing\Model\ContentPage\Field\Handler\Url
 {
-
-    /**
-     * @var StoreManagerInterface
-     */
-    private $storeManager;
-
-    /**
-     * Url constructor.
-     * @param StoreManagerInterface $storeManager
-     */
-    public function __construct(
-        StoreManagerInterface $storeManager)
-    {
-        $this->storeManager = $storeManager;
-    }
-
-    /**
-     * @inheritDoc
-     * @param PageInterface $item
-     * @throws NoSuchEntityException
-     */
-    public function handle(DataObject $item, string $attributeCode)
-    {
-        $store = $this->storeManager->getStore();
-        return $store->getBaseUrl() . $item->getIdentifier();
-        //return $item->getIdentifier();
-    }
 }

--- a/Model/ContentPage/Field/Handler/Url.php
+++ b/Model/ContentPage/Field/Handler/Url.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Model\ContentPage\Field\Handler;
+
+use HawkSearch\EsIndexing\Model\Indexing\FieldHandlerInterface;
+use Magento\Cms\Api\Data\PageInterface;
+use Magento\Framework\DataObject;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\StoreManagerInterface;
+
+class Url implements FieldHandlerInterface
+{
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * Url constructor.
+     * @param StoreManagerInterface $storeManager
+     */
+    public function __construct(
+        StoreManagerInterface $storeManager)
+    {
+        $this->storeManager = $storeManager;
+    }
+
+    /**
+     * @inheritDoc
+     * @param PageInterface $item
+     * @throws NoSuchEntityException
+     */
+    public function handle(DataObject $item, string $attributeCode)
+    {
+        $store = $this->storeManager->getStore();
+        return $store->getBaseUrl() . $item->getIdentifier();
+        //return $item->getIdentifier();
+    }
+}

--- a/Model/Hierarchy/Attribute/Handler/HierarchyId.php
+++ b/Model/Hierarchy/Attribute/Handler/HierarchyId.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2022 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -14,19 +14,19 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\Hierarchy\Attribute\Handler;
 
-use HawkSearch\EsIndexing\Model\Indexing\AttributeHandlerInterface;
-use Magento\Catalog\Api\Data\CategoryInterface;
-use Magento\Framework\DataObject;
+use HawkSearch\Connector\Compatibility\PublicContractDeprecation;
 
-class HierarchyId implements AttributeHandlerInterface
+PublicContractDeprecation::triggerClassDeprecationMessage(
+    HierarchyId::class,
+    '0.7.0',
+    \HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\HierarchyId::class,
+    'In favour of a new Field Handlers logic.'
+);
+
+/**
+ * @deprecated 0.7.0 In favour of a new Field Handlers logic
+ * @see \HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\HierarchyId
+ */
+class HierarchyId extends \HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\HierarchyId
 {
-
-    /**
-     * @inheritDoc
-     * @param CategoryInterface $item
-     */
-    public function handle(DataObject $item, string $attributeCode)
-    {
-        return (int)$item->getId();
-    }
 }

--- a/Model/Hierarchy/Attribute/Handler/IsActive.php
+++ b/Model/Hierarchy/Attribute/Handler/IsActive.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2022 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -14,19 +14,19 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\Hierarchy\Attribute\Handler;
 
-use HawkSearch\EsIndexing\Model\Indexing\AttributeHandlerInterface;
-use Magento\Catalog\Api\Data\CategoryInterface;
-use Magento\Framework\DataObject;
+use HawkSearch\Connector\Compatibility\PublicContractDeprecation;
 
-class IsActive implements AttributeHandlerInterface
+PublicContractDeprecation::triggerClassDeprecationMessage(
+    IsActive::class,
+    '0.7.0',
+    \HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\IsActive::class,
+    'In favour of a new Field Handlers logic.'
+);
+
+/**
+ * @deprecated 0.7.0 In favour of a new Field Handlers logic
+ * @see \HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\IsActive
+ */
+class IsActive extends \HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\IsActive
 {
-
-    /**
-     * @inheritDoc
-     * @param CategoryInterface $item
-     */
-    public function handle(DataObject $item, string $attributeCode)
-    {
-        return (bool)$item->getIsActive();
-    }
 }

--- a/Model/Hierarchy/Attribute/Handler/Name.php
+++ b/Model/Hierarchy/Attribute/Handler/Name.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2023 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -14,24 +14,19 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\Hierarchy\Attribute\Handler;
 
-use HawkSearch\EsIndexing\Model\Indexing\AttributeHandlerInterface;
-use Magento\Catalog\Api\Data\CategoryInterface;
-use Magento\Framework\DataObject;
+use HawkSearch\Connector\Compatibility\PublicContractDeprecation;
 
-class Name implements AttributeHandlerInterface
+PublicContractDeprecation::triggerClassDeprecationMessage(
+    Name::class,
+    '0.7.0',
+    \HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\Name::class,
+    'In favour of a new Field Handlers logic.'
+);
+
+/**
+ * @deprecated 0.7.0 In favour of a new Field Handlers logic
+ * @see \HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\Name
+ */
+class Name extends \HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\Name
 {
-    public const PARENT_HIERARCHY_NAME = 'category';
-
-    /**
-     * @inheritDoc
-     * @param CategoryInterface $item
-     */
-    public function handle(DataObject $item, string $attributeCode)
-    {
-        if ($item->getLevel() == 1) {
-            return self::PARENT_HIERARCHY_NAME;
-        } else {
-            return $item->getName();
-        }
-    }
 }

--- a/Model/Hierarchy/Attribute/Handler/ParentHierarchyId.php
+++ b/Model/Hierarchy/Attribute/Handler/ParentHierarchyId.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2022 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -14,23 +14,19 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\Hierarchy\Attribute\Handler;
 
-use HawkSearch\EsIndexing\Model\Indexing\AttributeHandlerInterface;
-use Magento\Catalog\Api\Data\CategoryInterface;
-use Magento\Framework\DataObject;
+use HawkSearch\Connector\Compatibility\PublicContractDeprecation;
 
-class ParentHierarchyId implements AttributeHandlerInterface
+PublicContractDeprecation::triggerClassDeprecationMessage(
+    ParentHierarchyId::class,
+    '0.7.0',
+    \HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\ParentHierarchyId::class,
+    'In favour of a new Field Handlers logic.'
+);
+
+/**
+ * @deprecated 0.7.0 In favour of a new Field Handlers logic
+ * @see \HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\ParentHierarchyId
+ */
+class ParentHierarchyId extends \HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\ParentHierarchyId
 {
-
-    /**
-     * @inheritDoc
-     * @param CategoryInterface $item
-     */
-    public function handle(DataObject $item, string $attributeCode)
-    {
-        if ($item->getLevel() == 1) {
-            return 0;
-        } else {
-            return (int)$item->getParentId();
-        }
-    }
 }

--- a/Model/Hierarchy/Field/Handler/HierarchyId.php
+++ b/Model/Hierarchy/Field/Handler/HierarchyId.php
@@ -12,21 +12,21 @@
  */
 declare(strict_types=1);
 
-namespace HawkSearch\EsIndexing\Model\Product\Attribute\Handler;
+namespace HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler;
 
-use HawkSearch\Connector\Compatibility\PublicContractDeprecation;
+use HawkSearch\EsIndexing\Model\Indexing\FieldHandlerInterface;
+use Magento\Catalog\Api\Data\CategoryInterface;
+use Magento\Framework\DataObject;
 
-PublicContractDeprecation::triggerClassDeprecationMessage(
-    Composite::class,
-    '0.7.0',
-    \HawkSearch\EsIndexing\Model\Product\Field\Handler\Composite::class,
-    'In favour of a new Field Handlers logic.'
-);
-
-/**
- * @deprecated 0.7.0 In favour of a new Field Handlers logic
- * @see \HawkSearch\EsIndexing\Model\Product\Field\Handler\Composite
- */
-class Composite extends \HawkSearch\EsIndexing\Model\Product\Field\Handler\Composite
+class HierarchyId implements FieldHandlerInterface
 {
+
+    /**
+     * @inheritDoc
+     * @param CategoryInterface $item
+     */
+    public function handle(DataObject $item, string $attributeCode)
+    {
+        return (int)$item->getId();
+    }
 }

--- a/Model/Hierarchy/Field/Handler/IsActive.php
+++ b/Model/Hierarchy/Field/Handler/IsActive.php
@@ -12,21 +12,21 @@
  */
 declare(strict_types=1);
 
-namespace HawkSearch\EsIndexing\Model\Product\Attribute\Handler;
+namespace HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler;
 
-use HawkSearch\Connector\Compatibility\PublicContractDeprecation;
+use HawkSearch\EsIndexing\Model\Indexing\FieldHandlerInterface;
+use Magento\Catalog\Api\Data\CategoryInterface;
+use Magento\Framework\DataObject;
 
-PublicContractDeprecation::triggerClassDeprecationMessage(
-    Composite::class,
-    '0.7.0',
-    \HawkSearch\EsIndexing\Model\Product\Field\Handler\Composite::class,
-    'In favour of a new Field Handlers logic.'
-);
-
-/**
- * @deprecated 0.7.0 In favour of a new Field Handlers logic
- * @see \HawkSearch\EsIndexing\Model\Product\Field\Handler\Composite
- */
-class Composite extends \HawkSearch\EsIndexing\Model\Product\Field\Handler\Composite
+class IsActive implements FieldHandlerInterface
 {
+
+    /**
+     * @inheritDoc
+     * @param CategoryInterface $item
+     */
+    public function handle(DataObject $item, string $attributeCode)
+    {
+        return (bool)$item->getIsActive();
+    }
 }

--- a/Model/Hierarchy/Field/Handler/Name.php
+++ b/Model/Hierarchy/Field/Handler/Name.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler;
+
+use HawkSearch\EsIndexing\Model\Indexing\FieldHandlerInterface;
+use Magento\Catalog\Api\Data\CategoryInterface;
+use Magento\Framework\DataObject;
+
+class Name implements FieldHandlerInterface
+{
+    public const PARENT_HIERARCHY_NAME = 'category';
+
+    /**
+     * @inheritDoc
+     * @param CategoryInterface $item
+     */
+    public function handle(DataObject $item, string $attributeCode)
+    {
+        if ($item->getLevel() == 1) {
+            return self::PARENT_HIERARCHY_NAME;
+        } else {
+            return $item->getName();
+        }
+    }
+}

--- a/Model/Hierarchy/Field/Handler/ParentHierarchyId.php
+++ b/Model/Hierarchy/Field/Handler/ParentHierarchyId.php
@@ -12,21 +12,25 @@
  */
 declare(strict_types=1);
 
-namespace HawkSearch\EsIndexing\Model\Product\Attribute\Handler;
+namespace HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler;
 
-use HawkSearch\Connector\Compatibility\PublicContractDeprecation;
+use HawkSearch\EsIndexing\Model\Indexing\FieldHandlerInterface;
+use Magento\Catalog\Api\Data\CategoryInterface;
+use Magento\Framework\DataObject;
 
-PublicContractDeprecation::triggerClassDeprecationMessage(
-    Composite::class,
-    '0.7.0',
-    \HawkSearch\EsIndexing\Model\Product\Field\Handler\Composite::class,
-    'In favour of a new Field Handlers logic.'
-);
-
-/**
- * @deprecated 0.7.0 In favour of a new Field Handlers logic
- * @see \HawkSearch\EsIndexing\Model\Product\Field\Handler\Composite
- */
-class Composite extends \HawkSearch\EsIndexing\Model\Product\Field\Handler\Composite
+class ParentHierarchyId implements FieldHandlerInterface
 {
+
+    /**
+     * @inheritDoc
+     * @param CategoryInterface $item
+     */
+    public function handle(DataObject $item, string $attributeCode)
+    {
+        if ($item->getLevel() == 1) {
+            return 0;
+        } else {
+            return (int)$item->getParentId();
+        }
+    }
 }

--- a/Model/Indexer/Category.php
+++ b/Model/Indexer/Category.php
@@ -62,7 +62,8 @@ class Category implements IndexerActionInterface, MviewActionInterface
     {
         $this->output->writeln(
             sprintf(
-                'To trigger full reindex please use `%s` indexer.',
+                '<comment>Indexer `%s` can\'t be run for full reindexing. Please run `%s` indexer instead.</comment>',
+                self::INDEXER_ID,
                 EntitiesIndexer::INDEXER_ID
             )
         );

--- a/Model/Indexer/ContentPage.php
+++ b/Model/Indexer/ContentPage.php
@@ -61,7 +61,8 @@ class ContentPage implements IndexerActionInterface, MviewActionInterface
     {
         $this->output->writeln(
             sprintf(
-                'To trigger full reindex please use `%s` indexer.',
+                '<comment>Indexer `%s` can\'t be run for full reindexing. Please run `%s` indexer instead.</comment>',
+                self::INDEXER_ID,
                 EntitiesIndexer::INDEXER_ID
             )
         );

--- a/Model/Indexer/Product.php
+++ b/Model/Indexer/Product.php
@@ -72,7 +72,8 @@ class Product implements IndexerActionInterface, MviewActionInterface
     {
         $this->output->writeln(
             sprintf(
-                'To trigger full reindex please use `%s` indexer.',
+                '<comment>Indexer `%s` can\'t be run for full reindexing. Please run `%s` indexer instead.</comment>',
+                self::INDEXER_ID,
                 EntitiesIndexer::INDEXER_ID
             )
         );

--- a/Model/Indexing/AbstractEntityRebuild.php
+++ b/Model/Indexing/AbstractEntityRebuild.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2023 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -378,7 +378,7 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
      */
     protected function getAttributeValue(DataObject $item, string $attribute)
     {
-        return $this->getEntityType()->getAttributeHandler()->handle($item, $attribute);
+        return $this->getEntityType()->getFieldHandler()->handle($item, $attribute);
     }
 
     /**

--- a/Model/Indexing/AttributeHandler/Composite.php
+++ b/Model/Indexing/AttributeHandler/Composite.php
@@ -71,7 +71,7 @@ class Composite implements AttributeHandlerInterface
      */
     public function handle(DataObject $item, string $attributeCode)
     {
-        $handler = $this->getObject( $this->handlers[$attributeCode] ?? $this->handlers[self::HANDLER_DEFAULT_NAME]);
+        $handler = $this->getHandler($attributeCode);
 
         return $handler->handle($item, $attributeCode);
     }
@@ -80,7 +80,7 @@ class Composite implements AttributeHandlerInterface
      * @param string $attributeCode
      * @return AttributeHandlerInterface
      */
-    protected function getHandler(string $attributeCode)
+    protected function getHandler(string $attributeCode): AttributeHandlerInterface
     {
         return $this->getObject( $this->handlers[$attributeCode] ?? $this->handlers[self::HANDLER_DEFAULT_NAME]);
     }
@@ -88,8 +88,9 @@ class Composite implements AttributeHandlerInterface
     /**
      * @param string $instanceName
      * @return AttributeHandlerInterface
+     * @throws \InvalidArgumentException
      */
-    private function getObject(string $instanceName)
+    private function getObject(string $instanceName): AttributeHandlerInterface
     {
         $instance = $this->objectManager->create($instanceName);
         if (!$instance instanceof AttributeHandlerInterface) {

--- a/Model/Indexing/AttributeHandler/Composite.php
+++ b/Model/Indexing/AttributeHandler/Composite.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2023 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -14,91 +14,19 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\Indexing\AttributeHandler;
 
-use HawkSearch\EsIndexing\Model\Indexing\AttributeHandlerInterface;
-use Magento\Framework\DataObject;
-use Magento\Framework\ObjectManagerInterface;
+use HawkSearch\Connector\Compatibility\PublicContractDeprecation;
 
-class Composite implements AttributeHandlerInterface
+PublicContractDeprecation::triggerClassDeprecationMessage(
+    Composite::class,
+    '0.7.0',
+    \HawkSearch\EsIndexing\Model\Indexing\FieldHandler\Composite::class,
+    'In favour of a new Field Handlers logic.'
+);
+
+/**
+ * @deprecated 0.7.0 In favour of a new Field Handlers logic
+ * @see \HawkSearch\EsIndexing\Model\Indexing\FieldHandler\Composite
+ */
+class Composite extends \HawkSearch\EsIndexing\Model\Indexing\FieldHandler\Composite
 {
-    /**#@+
-     * Constants
-     */
-    public const HANDLER_DEFAULT_NAME = '__DEFAULT_HANDLER__';
-    /**#@-*/
-
-    /**
-     * @var string[]
-     */
-    protected $handlers = [
-        self::HANDLER_DEFAULT_NAME => DataObjectHandler::class
-    ];
-
-    /**
-     * @var ObjectManagerInterface
-     */
-    private $objectManager;
-
-    /**
-     * AttributeHandlerComposite constructor.
-     * @param AttributeHandlerInterface[] $handlers
-     */
-    public function __construct(
-        ObjectManagerInterface $objectManager,
-        array $handlers = []
-    ) {
-        $this->objectManager = $objectManager;
-        $this->mergeTypes($handlers);
-    }
-
-    /**
-     * Add or override handlers
-     *
-     * @param array $handlers
-     * @return void
-     */
-    protected function mergeTypes(array $handlers)
-    {
-        foreach ($handlers as $handler) {
-            if (isset($handler['attribute']) && isset($handler['class'])) {
-                $this->handlers[$handler['attribute']] = $handler['class'];
-            }
-        }
-    }
-
-    /**
-     * @inheritDoc
-     * @param DataObject $item
-     */
-    public function handle(DataObject $item, string $attributeCode)
-    {
-        $handler = $this->getHandler($attributeCode);
-
-        return $handler->handle($item, $attributeCode);
-    }
-
-    /**
-     * @param string $attributeCode
-     * @return AttributeHandlerInterface
-     */
-    protected function getHandler(string $attributeCode): AttributeHandlerInterface
-    {
-        return $this->getObject( $this->handlers[$attributeCode] ?? $this->handlers[self::HANDLER_DEFAULT_NAME]);
-    }
-
-    /**
-     * @param string $instanceName
-     * @return AttributeHandlerInterface
-     * @throws \InvalidArgumentException
-     */
-    private function getObject(string $instanceName): AttributeHandlerInterface
-    {
-        $instance = $this->objectManager->create($instanceName);
-        if (!$instance instanceof AttributeHandlerInterface) {
-            throw new \InvalidArgumentException(
-                get_class($instance) . ' isn\'t instance of ' . AttributeHandlerInterface::class
-            );
-        }
-
-        return $instance;
-    }
 }

--- a/Model/Indexing/AttributeHandler/DataObjectHandler.php
+++ b/Model/Indexing/AttributeHandler/DataObjectHandler.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2023 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -14,17 +14,19 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\Indexing\AttributeHandler;
 
-use HawkSearch\EsIndexing\Model\Indexing\AttributeHandlerInterface;
-use Magento\Framework\DataObject;
+use HawkSearch\Connector\Compatibility\PublicContractDeprecation;
 
-class DataObjectHandler implements AttributeHandlerInterface
+PublicContractDeprecation::triggerClassDeprecationMessage(
+    DataObjectHandler::class,
+    '0.7.0',
+    \HawkSearch\EsIndexing\Model\Indexing\FieldHandler\DataObjectHandler::class,
+    'In favour of a new Field Handlers logic.'
+);
+
+/**
+ * @deprecated 0.7.0 In favour of a new Field Handlers logic
+ * @see \HawkSearch\EsIndexing\Model\Indexing\FieldHandler\DataObjectHandler
+ */
+class DataObjectHandler extends \HawkSearch\EsIndexing\Model\Indexing\FieldHandler\DataObjectHandler
 {
-
-    /**
-     * @inheritDoc
-     */
-    public function handle(DataObject $item, string $attributeCode)
-    {
-        return $item->getData($attributeCode);
-    }
 }

--- a/Model/Indexing/Entity/ContentPage/EntityRebuild.php
+++ b/Model/Indexing/Entity/ContentPage/EntityRebuild.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2023 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/Model/Indexing/Entity/Hierarchy/ItemsDataProvider.php
+++ b/Model/Indexing/Entity/Hierarchy/ItemsDataProvider.php
@@ -93,7 +93,8 @@ class ItemsDataProvider implements ItemsDataProviderInterface
         ];
         $pathFilterRegex = "(" . implode('|', $pathRegexGroups) . ")";
         $categories = $category->getCategories($category->getParentId(), 0, false, true, false);
-        $categories->addPathFilter($pathFilterRegex);
+        $categories->addPathFilter($pathFilterRegex)
+            ->addAttributeToSelect('name');
 
         if ($entityIds && count($entityIds) > 0) {
             $categories->addIdFilter($entityIds);

--- a/Model/Indexing/Entity/LandingPage/EntityRebuild.php
+++ b/Model/Indexing/Entity/LandingPage/EntityRebuild.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2023 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -22,7 +22,7 @@ use HawkSearch\Connector\Logger\LoggerFactoryInterface;
 use HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild;
 use HawkSearch\EsIndexing\Model\Indexing\ContextInterface;
 use HawkSearch\EsIndexing\Model\Indexing\EntityTypePoolInterface;
-use HawkSearch\EsIndexing\Model\LandingPage\Attribute\Handler\CustomUrl;
+use HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\CustomUrl;
 use Magento\Catalog\Api\Data\CategoryInterface;
 use Magento\Catalog\Model\Category;
 use Magento\Framework\App\CacheInterface as Cache;
@@ -78,7 +78,7 @@ class EntityRebuild extends AbstractEntityRebuild
     /**
      * @var CustomUrl
      */
-    private $customUrlAttribute;
+    private $customUrlHandler;
 
     /**
      * @param EntityTypePoolInterface $entityTypePool
@@ -91,7 +91,7 @@ class EntityRebuild extends AbstractEntityRebuild
      * @param SerializerInterface $serializer
      * @param LandingPageManagementInterface $landingPageManagement
      * @param LandingPageInterfaceFactory $landingPageFactory
-     * @param CustomUrl $customUrlAttribute
+     * @param CustomUrl $customUrlHandler
      */
     public function __construct(
         EntityTypePoolInterface $entityTypePool,
@@ -104,7 +104,7 @@ class EntityRebuild extends AbstractEntityRebuild
         SerializerInterface $serializer,
         LandingPageManagementInterface $landingPageManagement,
         LandingPageInterfaceFactory $landingPageFactory,
-        CustomUrl $customUrlAttribute
+        CustomUrl $customUrlHandler
     ) {
         parent::__construct(
             $entityTypePool,
@@ -118,7 +118,7 @@ class EntityRebuild extends AbstractEntityRebuild
         $this->serializer = $serializer;
         $this->landingPageManagement = $landingPageManagement;
         $this->landingPageFactory = $landingPageFactory;
-        $this->customUrlAttribute = $customUrlAttribute;
+        $this->customUrlHandler = $customUrlHandler;
     }
 
     /**
@@ -159,7 +159,7 @@ class EntityRebuild extends AbstractEntityRebuild
      */
     protected function isItemNew(DataObject $item): bool
     {
-        $customUrl = $this->customUrlAttribute->handle($item, LandingPageInterface::FIELD_CUSTOM_URL);
+        $customUrl = $this->customUrlHandler->handle($item, LandingPageInterface::FIELD_CUSTOM_URL);
 
         return !array_key_exists($this->getEntityUniqueId($item), $this->getCustomFieldMap())
             && !array_key_exists($customUrl, $this->getCustomUrlMap());

--- a/Model/Indexing/Entity/LandingPage/ItemsDataProvider.php
+++ b/Model/Indexing/Entity/LandingPage/ItemsDataProvider.php
@@ -95,6 +95,7 @@ class ItemsDataProvider implements ItemsDataProviderInterface
         $pathFilterRegex = "(" . implode('|', $pathRegexGroups) . ")";
         $categories = $category->getCategories($category->getParentId(), 0, false, true, false);
         $categories->addPathFilter($pathFilterRegex)
+            ->addAttributeToSelect('name')
             ->addAttributeToSort('entity_id')
             ->addAttributeToSort('parent_id')
             ->addAttributeToSort('position');

--- a/Model/Indexing/EntityTypeInterface.php
+++ b/Model/Indexing/EntityTypeInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2023 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -14,6 +14,11 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\Indexing;
 
+
+/**
+ * @method FieldHandlerInterface getFieldHandler() Use this method in your class implementations for smooth transitions
+ *          since 0.9.0
+ */
 interface EntityTypeInterface
 {
     /**
@@ -49,9 +54,19 @@ interface EntityTypeInterface
     public function getItemsIndexer() : ItemsIndexerInterface;
 
     /**
-     * @return AttributeHandlerInterface
+     * @deprecated 0.7.0 in favour of a new Field Handlers logic
+     * @see self::getFieldHandler()
+     * @return AttributeHandlerInterface|FieldHandlerInterface
      */
-    public function getAttributeHandler() : AttributeHandlerInterface;
+    public function getAttributeHandler() : FieldHandlerInterface;
 
+    /**
+     * @return FieldHandlerInterface
+     */
+    /*public function getFieldHandler() : FieldHandlerInterface;*/
+
+    /**
+     * @return AbstractConfigHelper
+     */
     public function getConfigHelper() : AbstractConfigHelper;
 }

--- a/Model/Indexing/FieldHandler/Composite.php
+++ b/Model/Indexing/FieldHandler/Composite.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Model\Indexing\FieldHandler;
+
+use HawkSearch\EsIndexing\Model\Indexing\FieldHandlerInterface;
+use Magento\Framework\DataObject;
+use Magento\Framework\ObjectManagerInterface;
+
+class Composite implements FieldHandlerInterface
+{
+    /**#@+
+     * Constants
+     */
+    public const HANDLER_DEFAULT_NAME = '__DEFAULT_HANDLER__';
+    /**#@-*/
+
+    /**
+     * @var string[]
+     */
+    protected $handlers = [
+        self::HANDLER_DEFAULT_NAME => DataObjectHandler::class
+    ];
+
+    /**
+     * @var ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * Composite constructor.
+     *
+     * @param FieldHandlerInterface[] $handlers
+     */
+    public function __construct(
+        ObjectManagerInterface $objectManager,
+        array $handlers = []
+    ) {
+        $this->objectManager = $objectManager;
+        $this->mergeTypes($handlers);
+    }
+
+    /**
+     * @inheritDoc
+     * @param DataObject $item
+     */
+    public function handle(DataObject $item, string $attributeCode)
+    {
+        $handler = $this->getHandler($attributeCode);
+
+        return $handler->handle($item, $attributeCode);
+    }
+
+    /**
+     * Add or override handlers
+     *
+     * @param array $handlers
+     * @return void
+     */
+    protected function mergeTypes(array $handlers)
+    {
+        foreach ($handlers as $handler) {
+            if (isset($handler['attribute']) && isset($handler['class'])) {
+                $this->handlers[$handler['attribute']] = $handler['class'];
+            }
+        }
+    }
+
+    /**
+     * @param string $attributeCode
+     * @return FieldHandlerInterface
+     */
+    protected function getHandler(string $attributeCode): FieldHandlerInterface
+    {
+        return $this->getObject( $this->handlers[$attributeCode] ?? $this->handlers[self::HANDLER_DEFAULT_NAME]);
+    }
+
+    /**
+     * @param string $instanceName
+     * @return FieldHandlerInterface
+     * @throws \InvalidArgumentException
+     */
+    private function getObject(string $instanceName): FieldHandlerInterface
+    {
+        $instance = $this->objectManager->create($instanceName);
+        if (!$instance instanceof FieldHandlerInterface) {
+            throw new \InvalidArgumentException(
+                get_class($instance) . ' isn\'t instance of ' . FieldHandlerInterface::class
+            );
+        }
+
+        return $instance;
+    }
+}

--- a/Model/Indexing/FieldHandler/DataObjectHandler.php
+++ b/Model/Indexing/FieldHandler/DataObjectHandler.php
@@ -12,21 +12,18 @@
  */
 declare(strict_types=1);
 
-namespace HawkSearch\EsIndexing\Model\Product\Attribute\Handler;
+namespace HawkSearch\EsIndexing\Model\Indexing\FieldHandler;
 
-use HawkSearch\Connector\Compatibility\PublicContractDeprecation;
+use HawkSearch\EsIndexing\Model\Indexing\FieldHandlerInterface;
+use Magento\Framework\DataObject;
 
-PublicContractDeprecation::triggerClassDeprecationMessage(
-    Composite::class,
-    '0.7.0',
-    \HawkSearch\EsIndexing\Model\Product\Field\Handler\Composite::class,
-    'In favour of a new Field Handlers logic.'
-);
-
-/**
- * @deprecated 0.7.0 In favour of a new Field Handlers logic
- * @see \HawkSearch\EsIndexing\Model\Product\Field\Handler\Composite
- */
-class Composite extends \HawkSearch\EsIndexing\Model\Product\Field\Handler\Composite
+class DataObjectHandler implements FieldHandlerInterface
 {
+    /**
+     * @inheritDoc
+     */
+    public function handle(DataObject $item, string $attributeCode)
+    {
+        return $item->getData($attributeCode);
+    }
 }

--- a/Model/Indexing/FieldHandlerInterface.php
+++ b/Model/Indexing/FieldHandlerInterface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ * Copyright (c) 2023 Hawksearch (www.hawksearch.com) - All Rights Reserved
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -14,19 +14,14 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\Indexing;
 
-use HawkSearch\Connector\Compatibility\PublicContractDeprecation;
+use Magento\Framework\DataObject;
 
-PublicContractDeprecation::triggerInterfaceDeprecationMessage(
-    AttributeHandlerInterface::class,
-    '0.7.0',
-    FieldHandlerInterface::class,
-    'In favour of a new Field Handlers logic.'
-);
-
-/**
- * @deprecated 0.7.0 In favour of a new Field Handlers logic
- * @see FieldHandlerInterface
- */
-interface AttributeHandlerInterface extends FieldHandlerInterface
+interface FieldHandlerInterface
 {
+    /**
+     * @param DataObject $item
+     * @param string $attributeCode
+     * @return mixed
+     */
+    public function handle(DataObject $item, string $attributeCode);
 }

--- a/Model/LandingPage/Attribute/Handler/CustomSortList.php
+++ b/Model/LandingPage/Attribute/Handler/CustomSortList.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2022 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -14,47 +14,19 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\LandingPage\Attribute\Handler;
 
-use HawkSearch\EsIndexing\Model\Indexing\AttributeHandlerInterface;
-use HawkSearch\EsIndexing\Model\Indexing\EntityType\ProductEntityType;
-use HawkSearch\EsIndexing\Model\Indexing\EntityType\ProductEntityTypeFactory;
-use Magento\Catalog\Api\Data\CategoryInterface;
-use Magento\Catalog\Model\Category;
-use Magento\Framework\DataObject;
+use HawkSearch\Connector\Compatibility\PublicContractDeprecation;
 
-class CustomSortList implements AttributeHandlerInterface
+PublicContractDeprecation::triggerClassDeprecationMessage(
+    CustomSortList::class,
+    '0.7.0',
+    \HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\CustomSortList::class,
+    'In favour of a new Field Handlers logic.'
+);
+
+/**
+ * @deprecated 0.7.0 In favour of a new Field Handlers logic
+ * @see \HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\CustomSortList
+ */
+class CustomSortList extends \HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\CustomSortList
 {
-    /**
-     * @var ProductEntityTypeFactory
-     */
-    private $productEntityTypeFactory;
-
-    /**
-     * @param ProductEntityTypeFactory $productEntityTypeFactory
-     */
-    public function __construct(ProductEntityTypeFactory $productEntityTypeFactory)
-    {
-        $this->productEntityTypeFactory = $productEntityTypeFactory;
-    }
-
-    /**
-     * @inheritDoc
-     * @param CategoryInterface|Category $item
-     */
-    public function handle(DataObject $item, string $attributeCode)
-    {
-        $positionsHash = $item->getProductsPosition();
-        $productIds = array_keys($positionsHash);
-        $positions = array_values($positionsHash);
-        asort($positions, SORT_NUMERIC);
-        $productIds = array_replace($positions, $productIds);
-
-        /** @var ProductEntityType $productEntityType */
-        $productEntityType = $this->productEntityTypeFactory->create();
-        $productIds = array_map(
-            function ($v) use ($productEntityType) {return $productEntityType->getUniqueId((string)$v);},
-            $productIds
-        );
-
-        return implode(',', $productIds);
-    }
 }

--- a/Model/LandingPage/Attribute/Handler/CustomUrl.php
+++ b/Model/LandingPage/Attribute/Handler/CustomUrl.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2022 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -14,29 +14,19 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\LandingPage\Attribute\Handler;
 
-use HawkSearch\EsIndexing\Model\Indexing\AttributeHandlerInterface;
-use Magento\Catalog\Api\Data\CategoryInterface;
-use Magento\Catalog\Model\Category;
-use Magento\Framework\DataObject;
+use HawkSearch\Connector\Compatibility\PublicContractDeprecation;
 
-class CustomUrl implements AttributeHandlerInterface
+PublicContractDeprecation::triggerClassDeprecationMessage(
+    CustomUrl::class,
+    '0.7.0',
+    \HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\CustomUrl::class,
+    'In favour of a new Field Handlers logic.'
+);
+
+/**
+ * @deprecated 0.7.0 In favour of a new Field Handlers logic
+ * @see \HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\CustomUrl
+ */
+class CustomUrl extends \HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\CustomUrl
 {
-    /**
-     * @inheritDoc
-     * @todo implement handler which can get other attribute values or has access to the final entity
-     * @param CategoryInterface $item
-     */
-    public function handle(DataObject $item, string $attributeCode)
-    {
-        return sprintf("%s", $this->getUrl($item));
-    }
-
-    /**
-     * @param Category|CategoryInterface $category
-     * @return string|null
-     */
-    protected function getUrl(Category $category)
-    {
-        return str_replace($category->getUrlInstance()->getBaseUrl(), '', $category->getUrl());
-    }
 }

--- a/Model/LandingPage/Attribute/Handler/DefaultHandler.php
+++ b/Model/LandingPage/Attribute/Handler/DefaultHandler.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2023 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -14,28 +14,19 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\LandingPage\Attribute\Handler;
 
-use HawkSearch\Connector\Helper\DataObjectHelper;
-use HawkSearch\EsIndexing\Model\Indexing\AttributeHandler\DataObjectHandler;
-use Magento\Framework\DataObject;
+use HawkSearch\Connector\Compatibility\PublicContractDeprecation;
 
-class DefaultHandler extends DataObjectHandler
+PublicContractDeprecation::triggerClassDeprecationMessage(
+    DefaultHandler::class,
+    '0.7.0',
+    \HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\DefaultHandler::class,
+    'In favour of a new Field Handlers logic.'
+);
+
+/**
+ * @deprecated 0.7.0 In favour of a new Field Handlers logic
+ * @see \HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\DefaultHandler
+ */
+class DefaultHandler extends \HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\DefaultHandler
 {
-    /**
-     * @var DataObjectHelper
-     */
-    private $dataObjectHelper;
-
-    public function __construct(DataObjectHelper $dataObjectHelper)
-    {
-        $this->dataObjectHelper = $dataObjectHelper;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function handle(DataObject $item, string $attributeCode)
-    {
-        $attributeCode = $this->dataObjectHelper->camelCaseToSnakeCase($attributeCode);
-        return parent::handle($item, $attributeCode);
-    }
 }

--- a/Model/LandingPage/Attribute/Handler/NarrowXml.php
+++ b/Model/LandingPage/Attribute/Handler/NarrowXml.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2022 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -14,33 +14,19 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\LandingPage\Attribute\Handler;
 
-use HawkSearch\EsIndexing\Model\Indexing\AttributeHandlerInterface;
-use Magento\Catalog\Api\Data\CategoryInterface;
-use Magento\Framework\DataObject;
+use HawkSearch\Connector\Compatibility\PublicContractDeprecation;
 
-class NarrowXml implements AttributeHandlerInterface
+PublicContractDeprecation::triggerClassDeprecationMessage(
+    NarrowXml::class,
+    '0.7.0',
+    \HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\NarrowXml::class,
+    'In favour of a new Field Handlers logic.'
+);
+
+/**
+ * @deprecated 0.7.0 In favour of a new Field Handlers logic
+ * @see \HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\NarrowXml
+ */
+class NarrowXml extends \HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\NarrowXml
 {
-    /**
-     * @inheritDoc
-     * @param CategoryInterface $item
-     */
-    public function handle(DataObject $item, string $attributeCode)
-    {
-        $xml = simplexml_load_string(
-            '<?xml version="1.0" encoding="UTF-8"?>
-<Rule xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-RuleType="Group" Operator="All" />'
-        );
-        $rules = $xml->addChild('Rules');
-        $rule = $rules->addChild('Rule');
-        $rule->addAttribute('RuleType', 'Eval');
-        $rule->addAttribute('Operator', 'None');
-        $rule->addChild('Field', 'facet:category');
-        $rule->addChild('Condition', 'is');
-        $rule->addChild('Value', $item->getId());
-        $xml->addChild('Field');
-        $xml->addChild('Condition');
-        $xml->addChild('Value');
-        return $xml->asXML();
-    }
 }

--- a/Model/LandingPage/Field/Handler/CustomSortList.php
+++ b/Model/LandingPage/Field/Handler/CustomSortList.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Model\LandingPage\Field\Handler;
+
+use HawkSearch\EsIndexing\Model\Indexing\FieldHandlerInterface;
+use HawkSearch\EsIndexing\Model\Indexing\EntityType\ProductEntityType;
+use HawkSearch\EsIndexing\Model\Indexing\EntityType\ProductEntityTypeFactory;
+use Magento\Catalog\Api\Data\CategoryInterface;
+use Magento\Catalog\Model\Category;
+use Magento\Framework\DataObject;
+
+class CustomSortList implements FieldHandlerInterface
+{
+    /**
+     * @var ProductEntityTypeFactory
+     */
+    private $productEntityTypeFactory;
+
+    /**
+     * @param ProductEntityTypeFactory $productEntityTypeFactory
+     */
+    public function __construct(ProductEntityTypeFactory $productEntityTypeFactory)
+    {
+        $this->productEntityTypeFactory = $productEntityTypeFactory;
+    }
+
+    /**
+     * @inheritDoc
+     * @param CategoryInterface|Category $item
+     */
+    public function handle(DataObject $item, string $attributeCode)
+    {
+        $positionsHash = $item->getProductsPosition();
+        $productIds = array_keys($positionsHash);
+        $positions = array_values($positionsHash);
+        asort($positions, SORT_NUMERIC);
+        $productIds = array_replace($positions, $productIds);
+
+        /** @var ProductEntityType $productEntityType */
+        $productEntityType = $this->productEntityTypeFactory->create();
+        $productIds = array_map(
+            function ($v) use ($productEntityType) {return $productEntityType->getUniqueId((string)$v);},
+            $productIds
+        );
+
+        return implode(',', $productIds);
+    }
+}

--- a/Model/LandingPage/Field/Handler/CustomUrl.php
+++ b/Model/LandingPage/Field/Handler/CustomUrl.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Model\LandingPage\Field\Handler;
+
+use HawkSearch\EsIndexing\Model\Indexing\FieldHandlerInterface;
+use Magento\Catalog\Api\Data\CategoryInterface;
+use Magento\Catalog\Model\Category;
+use Magento\Framework\DataObject;
+
+class CustomUrl implements FieldHandlerInterface
+{
+    /**
+     * @inheritDoc
+     * @todo implement handler which can get other attribute values or has access to the final entity
+     * @param CategoryInterface $item
+     */
+    public function handle(DataObject $item, string $attributeCode)
+    {
+        return sprintf("%s", $this->getUrl($item));
+    }
+
+    /**
+     * @param Category|CategoryInterface $category
+     * @return string|null
+     */
+    protected function getUrl(Category $category)
+    {
+        return str_replace($category->getUrlInstance()->getBaseUrl(), '', $category->getUrl());
+    }
+}

--- a/Model/LandingPage/Field/Handler/DefaultHandler.php
+++ b/Model/LandingPage/Field/Handler/DefaultHandler.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Model\LandingPage\Field\Handler;
+
+use HawkSearch\Connector\Helper\DataObjectHelper;
+use HawkSearch\EsIndexing\Model\Indexing\FieldHandler\DataObjectHandler;
+use Magento\Framework\DataObject;
+
+class DefaultHandler extends DataObjectHandler
+{
+    /**
+     * @var DataObjectHelper
+     */
+    private $dataObjectHelper;
+
+    public function __construct(DataObjectHelper $dataObjectHelper)
+    {
+        $this->dataObjectHelper = $dataObjectHelper;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function handle(DataObject $item, string $attributeCode)
+    {
+        $attributeCode = $this->dataObjectHelper->camelCaseToSnakeCase($attributeCode);
+        return parent::handle($item, $attributeCode);
+    }
+}

--- a/Model/LandingPage/Field/Handler/NarrowXml.php
+++ b/Model/LandingPage/Field/Handler/NarrowXml.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Model\LandingPage\Field\Handler;
+
+use HawkSearch\EsIndexing\Model\Indexing\FieldHandlerInterface;
+use Magento\Catalog\Api\Data\CategoryInterface;
+use Magento\Framework\DataObject;
+
+class NarrowXml implements FieldHandlerInterface
+{
+    /**
+     * @inheritDoc
+     * @param CategoryInterface $item
+     */
+    public function handle(DataObject $item, string $attributeCode)
+    {
+        $xml = simplexml_load_string(
+            '<?xml version="1.0" encoding="UTF-8"?>
+<Rule xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+RuleType="Group" Operator="All" />'
+        );
+        $rules = $xml->addChild('Rules');
+        $rule = $rules->addChild('Rule');
+        $rule->addAttribute('RuleType', 'Eval');
+        $rule->addAttribute('Operator', 'None');
+        $rule->addChild('Field', 'facet:category');
+        $rule->addChild('Condition', 'is');
+        $rule->addChild('Value', $item->getId());
+        $xml->addChild('Field');
+        $xml->addChild('Condition');
+        $xml->addChild('Value');
+        return $xml->asXML();
+    }
+}

--- a/Model/Layout/ConfigProcessor/Vue/VueAdditionalParametersProcessor.php
+++ b/Model/Layout/ConfigProcessor/Vue/VueAdditionalParametersProcessor.php
@@ -61,8 +61,16 @@ class VueAdditionalParametersProcessor implements LayoutConfigProcessorInterface
     public function process($jsConfig)
     {
         $params = [];
+        $queryParam = [];
         if ($category = $this->getCategoryPage()) {
             $params['CustomUrl'] = $this->getCategoryPath($category);
+            $queryParam[] = 'visibility_catalog:true';
+        } else {
+            $queryParam[] = 'visibility_search:true';
+        }
+
+        if ($queryParam) {
+            $params['Query'] = implode(' AND ', $queryParam);
         }
 
         $jsConfig = $jsConfig ?? [];

--- a/Model/Product/Attribute/Handler/Category.php
+++ b/Model/Product/Attribute/Handler/Category.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2022 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -14,18 +14,20 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\Product\Attribute\Handler;
 
-use HawkSearch\EsIndexing\Model\Indexing\AttributeHandlerInterface;
-use Magento\Catalog\Api\Data\ProductInterface;
-use Magento\Framework\DataObject;
+use HawkSearch\Connector\Compatibility\PublicContractDeprecation;
 
-class Category implements AttributeHandlerInterface
+PublicContractDeprecation::triggerClassDeprecationMessage(
+    Category::class,
+    '0.7.0',
+    \HawkSearch\EsIndexing\Model\Product\Field\Handler\Category::class,
+    'In favour of a new Field Handlers logic.'
+);
+
+/**
+ * @deprecated 0.7.0 In favour of a new Field Handlers logic
+ * @see \HawkSearch\EsIndexing\Model\Product\Field\Handler\Category
+ */
+
+class Category extends \HawkSearch\EsIndexing\Model\Product\Field\Handler\Category
 {
-    /**
-     * @inheritDoc
-     * @param ProductInterface $item
-     */
-    public function handle(DataObject $item, string $attributeCode)
-    {
-        return $item->getCategoryIds();
-    }
 }

--- a/Model/Product/Attribute/Handler/DefaultHandler.php
+++ b/Model/Product/Attribute/Handler/DefaultHandler.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2022 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -14,49 +14,19 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\Product\Attribute\Handler;
 
-use HawkSearch\EsIndexing\Model\Indexing\AttributeHandlerInterface;
-use Magento\Catalog\Api\Data\ProductInterface;
-use Magento\Catalog\Model\ResourceModel\Eav\Attribute as AttributeResource;
-use Magento\Catalog\Model\ResourceModel\Product as ProductResource;
-use Magento\Framework\DataObject;
-use Magento\Framework\Exception\LocalizedException;
+use HawkSearch\Connector\Compatibility\PublicContractDeprecation;
 
-class DefaultHandler implements AttributeHandlerInterface
+PublicContractDeprecation::triggerClassDeprecationMessage(
+    DefaultHandler::class,
+    '0.7.0',
+    \HawkSearch\EsIndexing\Model\Product\Field\Handler\DefaultHandler::class,
+    'In favour of a new Field Handlers logic.'
+);
+
+/**
+ * @deprecated 0.7.0 In favour of a new Field Handlers logic
+ * @see \HawkSearch\EsIndexing\Model\Product\Field\Handler\DefaultHandler
+ */
+class DefaultHandler extends \HawkSearch\EsIndexing\Model\Product\Field\Handler\DefaultHandler
 {
-
-    /**
-     * @inheritDoc
-     * @param ProductInterface $item
-     * @throws LocalizedException
-     */
-    public function handle(DataObject $item, string $attributeCode)
-    {
-        $value = '';
-
-        /** @var ProductResource $productResource */
-        $productResource = $item->getResource();
-
-        /** @var AttributeResource $attributeResource */
-        $attributeResource = $productResource->getAttribute($attributeCode);
-        if ($attributeResource) {
-            $attributeResource->setData('store_id', $item->getStoreId());
-
-            $value = $item->getData($attributeCode);
-
-            if ($value !== null) {
-                if (!is_array($value) && $attributeResource->usesSource()) {
-                    $value = $item->getAttributeText($attributeCode);
-                    if (!is_scalar($value) && !is_array($value)) {
-                        $value = (string)$value;
-                    }
-                }
-
-                if ($value === false) {
-                    $value = $attributeResource->getFrontend()->getValue($item);
-                }
-            }
-        }
-
-        return $value;
-    }
 }

--- a/Model/Product/Attribute/Handler/ImageUrl.php
+++ b/Model/Product/Attribute/Handler/ImageUrl.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2022 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -14,95 +14,19 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\Product\Attribute\Handler;
 
-use HawkSearch\Connector\Helper\Url as UrlHelper;
-use HawkSearch\EsIndexing\Model\Config\Advanced as AdvancedConfig;
-use HawkSearch\EsIndexing\Model\Indexing\AttributeHandlerInterface;
-use Magento\Catalog\Api\Data\ProductInterface;
-use Magento\Catalog\Helper\Image as ImageHelper;
-use Magento\Catalog\Model\Product;
-use Magento\Framework\DataObject;
-use Magento\Framework\Exception\NoSuchEntityException;
-use Magento\Store\Model\StoreManagerInterface;
+use HawkSearch\Connector\Compatibility\PublicContractDeprecation;
 
-class ImageUrl implements AttributeHandlerInterface
+PublicContractDeprecation::triggerClassDeprecationMessage(
+    ImageUrl::class,
+    '0.7.0',
+    \HawkSearch\EsIndexing\Model\Product\Field\Handler\ImageUrl::class,
+    'In favour of a new Field Handlers logic.'
+);
+
+/**
+ * @deprecated 0.7.0 In favour of a new Field Handlers logic
+ * @see \HawkSearch\EsIndexing\Model\Product\Field\Handler\ImageUrl
+ */
+class ImageUrl extends \HawkSearch\EsIndexing\Model\Product\Field\Handler\ImageUrl
 {
-    protected const ATTRIBUTE_IMAGE_ID_MAP = [
-        'image_url' => 'product_base_image',
-        'thumbnail_url' => 'product_thumbnail_image'
-    ];
-
-    /**
-     * @var ImageHelper
-     */
-    private $imageHelper;
-
-    /**
-     * @var UrlHelper
-     */
-    private $urlHelper;
-
-    /**
-     * @var AdvancedConfig
-     */
-    private $advancedConfig;
-
-    /**
-     * @var StoreManagerInterface
-     */
-    private $storeManager;
-
-    /**
-     * ImageUrl constructor.
-     * @param ImageHelper $imageHelper
-     * @param UrlHelper $urlHelper
-     * @param AdvancedConfig $advancedConfig
-     * @param StoreManagerInterface $storeManager
-     */
-    public function __construct(
-        ImageHelper $imageHelper,
-        UrlHelper $urlHelper,
-        AdvancedConfig $advancedConfig,
-        StoreManagerInterface $storeManager
-    ) {
-        $this->imageHelper = $imageHelper;
-        $this->urlHelper = $urlHelper;
-        $this->advancedConfig = $advancedConfig;
-        $this->storeManager = $storeManager;
-    }
-
-    /**
-     * @inheritDoc
-     * @param ProductInterface $item
-     * @throws NoSuchEntityException
-     */
-    public function handle(DataObject $item, string $attributeCode)
-    {
-        $value = '';
-        if (array_key_exists($attributeCode, static::ATTRIBUTE_IMAGE_ID_MAP)) {
-            $value = $this->getImageIdUrl($item, static::ATTRIBUTE_IMAGE_ID_MAP[$attributeCode]);
-        }
-
-        return $value;
-    }
-
-    /**
-     * Get product image URL by image_id
-     * @param ProductInterface|Product $product
-     * @param string $imageId
-     * @return string
-     * @throws NoSuchEntityException
-     */
-    private function getImageIdUrl(ProductInterface $product, string $imageId)
-    {
-        $imageUrl = $this->imageHelper->init($product, $imageId)->getUrl();
-        $uri = $this->urlHelper->getUriInstance($imageUrl);
-
-        $store = $this->storeManager->getStore($product->getStoreId());
-        if ($this->advancedConfig->isRemovePubFromAssetsUrl($store)) {
-            /** @link  https://github.com/magento/magento2/issues/9111 */
-            $uri = $this->urlHelper->removeFromUriPath($uri, ['pub']);
-        }
-
-        return (string)$uri->withScheme('');
-    }
 }

--- a/Model/Product/Attribute/Handler/Url.php
+++ b/Model/Product/Attribute/Handler/Url.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2022 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -14,37 +14,19 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\Product\Attribute\Handler;
 
-use HawkSearch\EsIndexing\Model\Indexing\AttributeHandlerInterface;
-use Magento\Catalog\Api\Data\ProductInterface;
-use Magento\Framework\DataObject;
-use Magento\Framework\Exception\NoSuchEntityException;
-use Magento\Store\Model\StoreManagerInterface;
+use HawkSearch\Connector\Compatibility\PublicContractDeprecation;
 
-class Url implements AttributeHandlerInterface
+PublicContractDeprecation::triggerClassDeprecationMessage(
+    Url::class,
+    '0.7.0',
+    \HawkSearch\EsIndexing\Model\Product\Field\Handler\Url::class,
+    'In favour of a new Field Handlers logic.'
+);
+
+/**
+ * @deprecated 0.7.0 In favour of a new Field Handlers logic
+ * @see \HawkSearch\EsIndexing\Model\Product\Field\Handler\Url
+ */
+class Url extends \HawkSearch\EsIndexing\Model\Product\Field\Handler\Url
 {
-    /**
-     * @var StoreManagerInterface
-     */
-    private $storeManager;
-
-    /**
-     * Url constructor.
-     * @param StoreManagerInterface $storeManager
-     */
-    public function __construct(
-        StoreManagerInterface $storeManager)
-    {
-        $this->storeManager = $storeManager;
-    }
-
-    /**
-     * @inheritDoc
-     * @param ProductInterface $item
-     * @throws NoSuchEntityException
-     */
-    public function handle(DataObject $item, string $attributeCode)
-    {
-        $store = $this->storeManager->getStore($item->getStoreId());
-        return substr($item->getProductUrl(true), strlen($store->getBaseUrl()));
-    }
 }

--- a/Model/Product/Attributes.php
+++ b/Model/Product/Attributes.php
@@ -106,7 +106,8 @@ class Attributes
             'name',
             'category',
             'url',
-            'visibility'
+            'visibility_search',
+            'visibility_catalog',
         ];
     }
 

--- a/Model/Product/Field/Handler/Category.php
+++ b/Model/Product/Field/Handler/Category.php
@@ -12,21 +12,20 @@
  */
 declare(strict_types=1);
 
-namespace HawkSearch\EsIndexing\Model\Product\Attribute\Handler;
+namespace HawkSearch\EsIndexing\Model\Product\Field\Handler;
 
-use HawkSearch\Connector\Compatibility\PublicContractDeprecation;
+use HawkSearch\EsIndexing\Model\Indexing\FieldHandlerInterface;
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Framework\DataObject;
 
-PublicContractDeprecation::triggerClassDeprecationMessage(
-    Composite::class,
-    '0.7.0',
-    \HawkSearch\EsIndexing\Model\Product\Field\Handler\Composite::class,
-    'In favour of a new Field Handlers logic.'
-);
-
-/**
- * @deprecated 0.7.0 In favour of a new Field Handlers logic
- * @see \HawkSearch\EsIndexing\Model\Product\Field\Handler\Composite
- */
-class Composite extends \HawkSearch\EsIndexing\Model\Product\Field\Handler\Composite
+class Category implements FieldHandlerInterface
 {
+    /**
+     * @inheritDoc
+     * @param ProductInterface $item
+     */
+    public function handle(DataObject $item, string $attributeCode)
+    {
+        return $item->getCategoryIds();
+    }
 }

--- a/Model/Product/Field/Handler/Composite.php
+++ b/Model/Product/Field/Handler/Composite.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Model\Product\Field\Handler;
+
+use HawkSearch\EsIndexing\Model\Indexing\Entity\Product\ItemsDataProvider;
+use HawkSearch\EsIndexing\Model\Indexing\FieldHandlerInterface;
+use HawkSearch\EsIndexing\Model\Product\Attribute\ValueProcessorInterface;
+use HawkSearch\EsIndexing\Model\Product\ProductTypePoolInterface;
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Model\ResourceModel\Eav\Attribute as AttributeResource;
+use Magento\Catalog\Model\ResourceModel\Product as ProductResource;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\DataObject;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\ObjectManagerInterface;
+
+class Composite extends \HawkSearch\EsIndexing\Model\Indexing\FieldHandler\Composite
+{
+    /**
+     * @var array
+     */
+    private array $childrenCache = [];
+
+    /**
+     * @var ProductTypePoolInterface
+     */
+    private ProductTypePoolInterface $productTypePool;
+
+    /**
+     * @var ValueProcessorInterface
+     */
+    private ValueProcessorInterface $valueProcessor;
+
+    /**
+     * @var ItemsDataProvider
+     */
+    private ItemsDataProvider $childrenItemsDataProvider;
+
+    /**
+     * Composite constructor.
+     *
+     * @param ObjectManagerInterface $objectManager
+     * @param ProductTypePoolInterface $productTypePool
+     * @param ValueProcessorInterface $valueProcessor
+     * @param FieldHandlerInterface[] $handlers
+     * @param ItemsDataProvider|null $childrenItemsDataProvider
+     */
+    public function __construct(
+        ObjectManagerInterface $objectManager,
+        ProductTypePoolInterface $productTypePool,
+        ValueProcessorInterface $valueProcessor,
+        array $handlers = [],
+        ItemsDataProvider $childrenItemsDataProvider = null
+    ) {
+        parent::__construct($objectManager, $handlers);
+        $this->productTypePool = $productTypePool;
+        $this->valueProcessor = $valueProcessor;
+        $this->childrenItemsDataProvider = $childrenItemsDataProvider ?: ObjectManager::getInstance()->get(ItemsDataProvider::class);
+    }
+
+    /**
+     * @inheritDoc
+     * @param ProductInterface $item
+     * @throws LocalizedException
+     */
+    public function handle(DataObject $item, string $attributeCode)
+    {
+        $value = $this->formatValue(parent::handle($item, $attributeCode));
+        $relatedValues = [];
+
+        foreach ($this->getChildren($item) as $child) {
+            $relatedValues = array_merge($relatedValues, $this->formatValue($this->handle($child, $attributeCode)));
+        }
+
+        /** @var ProductResource $productResource */
+        $productResource = $item->getResource();
+        /** @var AttributeResource $attributeResource */
+        $attributeResource = $productResource->getAttribute($attributeCode);
+
+        if ($attributeResource) {
+            $value = $this->valueProcessor->process($attributeResource, $value, $relatedValues);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Safely apply values of array type.
+     *
+     * @param mixed $value
+     * @return array
+     */
+    private function formatValue($value)
+    {
+        $result = [];
+        if (is_array($value)) {
+            array_push($result, ...$value);
+        } else {
+            $result = (array)$value;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param ProductInterface|DataObject $item
+     * @return ProductInterface[]
+     */
+    private function getChildren(DataObject $item): array
+    {
+        if (!isset($this->childrenCache[$item->getId()])) {
+            $productType = $this->productTypePool->get($item->getTypeId());
+            $childrenCollection = [];
+            if ($children = $productType->getChildProducts($item)) {
+                $childIds = [];
+                foreach ($children as $child) {
+                    $childIds[] = $child->getId();
+                }
+                $childrenCollection = $this->childrenItemsDataProvider->getItems($item->getStoreId(), $childIds);
+            }
+
+            $this->childrenCache[$item->getId()] = $childrenCollection;
+        }
+
+        return $this->childrenCache[$item->getId()];
+    }
+}

--- a/Model/Product/Field/Handler/DefaultHandler.php
+++ b/Model/Product/Field/Handler/DefaultHandler.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Model\Product\Field\Handler;
+
+use HawkSearch\EsIndexing\Model\Indexing\FieldHandlerInterface;
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Model\ResourceModel\Eav\Attribute as AttributeResource;
+use Magento\Catalog\Model\ResourceModel\Product as ProductResource;
+use Magento\Framework\DataObject;
+use Magento\Framework\Exception\LocalizedException;
+
+class DefaultHandler implements FieldHandlerInterface
+{
+
+    /**
+     * @inheritDoc
+     * @param ProductInterface $item
+     * @throws LocalizedException
+     */
+    public function handle(DataObject $item, string $attributeCode)
+    {
+        $value = '';
+
+        /** @var ProductResource $productResource */
+        $productResource = $item->getResource();
+
+        /** @var AttributeResource $attributeResource */
+        $attributeResource = $productResource->getAttribute($attributeCode);
+        if ($attributeResource) {
+            $attributeResource->setData('store_id', $item->getStoreId());
+
+            $value = $item->getData($attributeCode);
+
+            if ($value !== null) {
+                if (!is_array($value) && $attributeResource->usesSource()) {
+                    $value = $item->getAttributeText($attributeCode);
+                    if (!is_scalar($value) && !is_array($value)) {
+                        $value = (string)$value;
+                    }
+                }
+
+                if ($value === false) {
+                    $value = $attributeResource->getFrontend()->getValue($item);
+                }
+            }
+        }
+
+        return $value;
+    }
+}

--- a/Model/Product/Field/Handler/ImageUrl.php
+++ b/Model/Product/Field/Handler/ImageUrl.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Model\Product\Field\Handler;
+
+use HawkSearch\Connector\Helper\Url as UrlHelper;
+use HawkSearch\EsIndexing\Model\Config\Advanced as AdvancedConfig;
+use HawkSearch\EsIndexing\Model\Indexing\FieldHandlerInterface;
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Helper\Image as ImageHelper;
+use Magento\Catalog\Model\Product;
+use Magento\Framework\DataObject;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\StoreManagerInterface;
+
+class ImageUrl implements FieldHandlerInterface
+{
+    protected const ATTRIBUTE_IMAGE_ID_MAP = [
+        'image_url' => 'product_base_image',
+        'thumbnail_url' => 'product_thumbnail_image'
+    ];
+
+    /**
+     * @var ImageHelper
+     */
+    private $imageHelper;
+
+    /**
+     * @var UrlHelper
+     */
+    private $urlHelper;
+
+    /**
+     * @var AdvancedConfig
+     */
+    private $advancedConfig;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * ImageUrl constructor.
+     * @param ImageHelper $imageHelper
+     * @param UrlHelper $urlHelper
+     * @param AdvancedConfig $advancedConfig
+     * @param StoreManagerInterface $storeManager
+     */
+    public function __construct(
+        ImageHelper $imageHelper,
+        UrlHelper $urlHelper,
+        AdvancedConfig $advancedConfig,
+        StoreManagerInterface $storeManager
+    ) {
+        $this->imageHelper = $imageHelper;
+        $this->urlHelper = $urlHelper;
+        $this->advancedConfig = $advancedConfig;
+        $this->storeManager = $storeManager;
+    }
+
+    /**
+     * @inheritDoc
+     * @param ProductInterface $item
+     * @throws NoSuchEntityException
+     */
+    public function handle(DataObject $item, string $attributeCode)
+    {
+        $value = '';
+        if (array_key_exists($attributeCode, static::ATTRIBUTE_IMAGE_ID_MAP)) {
+            $value = $this->getImageIdUrl($item, static::ATTRIBUTE_IMAGE_ID_MAP[$attributeCode]);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get product image URL by image_id
+     * @param ProductInterface|Product $product
+     * @param string $imageId
+     * @return string
+     * @throws NoSuchEntityException
+     */
+    private function getImageIdUrl(ProductInterface $product, string $imageId)
+    {
+        $imageUrl = $this->imageHelper->init($product, $imageId)->getUrl();
+        $uri = $this->urlHelper->getUriInstance($imageUrl);
+
+        $store = $this->storeManager->getStore($product->getStoreId());
+        if ($this->advancedConfig->isRemovePubFromAssetsUrl($store)) {
+            /** @link  https://github.com/magento/magento2/issues/9111 */
+            $uri = $this->urlHelper->removeFromUriPath($uri, ['pub']);
+        }
+
+        return (string)$uri->withScheme('');
+    }
+}

--- a/Model/Product/Field/Handler/Url.php
+++ b/Model/Product/Field/Handler/Url.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Model\Product\Field\Handler;
+
+use HawkSearch\EsIndexing\Model\Indexing\FieldHandlerInterface;
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Framework\DataObject;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\StoreManagerInterface;
+
+class Url implements FieldHandlerInterface
+{
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * Url constructor.
+     * @param StoreManagerInterface $storeManager
+     */
+    public function __construct(
+        StoreManagerInterface $storeManager)
+    {
+        $this->storeManager = $storeManager;
+    }
+
+    /**
+     * @inheritDoc
+     * @param ProductInterface $item
+     * @throws NoSuchEntityException
+     */
+    public function handle(DataObject $item, string $attributeCode)
+    {
+        $store = $this->storeManager->getStore($item->getStoreId());
+        return substr($item->getProductUrl(true), strlen($store->getBaseUrl()));
+    }
+}

--- a/Model/Product/Field/Handler/VisibilityCatalog.php
+++ b/Model/Product/Field/Handler/VisibilityCatalog.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Model\Product\Field\Handler;
+
+use HawkSearch\EsIndexing\Model\Indexing\FieldHandlerInterface;
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\Framework\DataObject;
+
+class VisibilityCatalog implements FieldHandlerInterface
+{
+    /**
+     * @var Visibility
+     */
+    private Visibility $visibility;
+
+    /**
+     * @param Visibility $visibility
+     */
+    public function __construct(
+        Visibility $visibility
+    )
+    {
+        $this->visibility = $visibility;
+    }
+
+    /**
+     * @inheritDoc
+     * @param ProductInterface $item
+     */
+    public function handle(DataObject $item, string $attributeCode)
+    {
+        return in_array($item->getVisibility(), $this->visibility->getVisibleInCatalogIds());
+    }
+}

--- a/Model/Product/Field/Handler/VisibilitySearch.php
+++ b/Model/Product/Field/Handler/VisibilitySearch.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Model\Product\Field\Handler;
+
+use HawkSearch\EsIndexing\Model\Indexing\FieldHandlerInterface;
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\Framework\DataObject;
+
+class VisibilitySearch implements FieldHandlerInterface
+{
+    /**
+     * @var Visibility
+     */
+    private Visibility $visibility;
+
+    /**
+     * @param Visibility $visibility
+     */
+    public function __construct(
+        Visibility $visibility
+    )
+    {
+        $this->visibility = $visibility;
+    }
+
+    /**
+     * @inheritDoc
+     * @param ProductInterface $item
+     */
+    public function handle(DataObject $item, string $attributeCode)
+    {
+        return in_array($item->getVisibility(), $this->visibility->getVisibleInSearchIds());
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1036,6 +1036,14 @@
                     <item name="attribute" xsi:type="string">category</item>
                     <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\Product\Field\Handler\Category</item>
                 </item>
+                <item name="visibility_search" xsi:type="array">
+                    <item name="attribute" xsi:type="string">visibility_search</item>
+                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\Product\Field\Handler\VisibilitySearch</item>
+                </item>
+                <item name="visibility_catalog" xsi:type="array">
+                    <item name="attribute" xsi:type="string">visibility_catalog</item>
+                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\Product\Field\Handler\VisibilityCatalog</item>
+                </item>
             </argument>
             <argument name="childrenItemsDataProvider" xsi:type="object">HawkSearch\EsIndexing\Model\Indexing\Entity\Product\ChildrenItemsDataProvider</argument>
         </arguments>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1133,21 +1133,18 @@
                  type="HawkSearch\EsIndexing\Model\Indexer\Entities\ActionEntityDefault">
         <arguments>
             <argument name="entityScheduler" xsi:type="object">HawkSearch\EsIndexing\Model\Indexer\Entities\Scheduler\Product</argument>
-            <argument name="publisher" xsi:type="object">HawkSearch\EsIndexing\Model\MessageQueue\BulkPublisher\Delta</argument>
         </arguments>
     </virtualType>
     <virtualType name="HawkSearch\EsIndexing\Model\Indexer\Entities\ActionEntityContentPage"
                  type="HawkSearch\EsIndexing\Model\Indexer\Entities\ActionEntityDefault">
         <arguments>
             <argument name="entityScheduler" xsi:type="object">HawkSearch\EsIndexing\Model\Indexer\Entities\Scheduler\ContentPage</argument>
-            <argument name="publisher" xsi:type="object">HawkSearch\EsIndexing\Model\MessageQueue\BulkPublisher\Delta</argument>
         </arguments>
     </virtualType>
     <virtualType name="HawkSearch\EsIndexing\Model\Indexer\Entities\ActionEntityCategory"
                  type="HawkSearch\EsIndexing\Model\Indexer\Entities\ActionEntityDefault">
         <arguments>
             <argument name="entityScheduler" xsi:type="object">HawkSearch\EsIndexing\Model\Indexer\Entities\Scheduler\Category</argument>
-            <argument name="publisher" xsi:type="object">HawkSearch\EsIndexing\Model\MessageQueue\BulkPublisher\Delta</argument>
         </arguments>
     </virtualType>
 

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -65,7 +65,9 @@
     <preference for="HawkSearch\EsIndexing\Logger\LoggerFactoryInterface"
                 type="HawkSearch\EsIndexing\Logger\LoggerFactory"/>
     <preference for="HawkSearch\EsIndexing\Model\Indexing\AttributeHandlerInterface"
-                type="HawkSearch\EsIndexing\Model\Indexing\AttributeHandler\DataObjectHandler"/>
+                type="HawkSearch\EsIndexing\Model\Indexing\FieldHandler\DataObjectHandler"/>
+    <preference for="HawkSearch\EsIndexing\Model\Indexing\FieldHandlerInterface"
+                type="HawkSearch\EsIndexing\Model\Indexing\FieldHandler\DataObjectHandler"/>
     <preference for="HawkSearch\EsIndexing\Model\Indexing\ItemsIndexerInterface"
                 type="HawkSearch\EsIndexing\Model\Indexing\ItemsIndexer\SearchedItemsIndexer"/>
     <preference for="HawkSearch\EsIndexing\Model\Product\Attribute\ValueProcessorInterface"
@@ -826,7 +828,13 @@
         <arguments>
             <argument name="rebuilder" xsi:type="object">HawkSearch\EsIndexing\Model\Indexing\Entity\Hierarchy\EntityRebuild\Proxy</argument>
             <argument name="itemsDataProvider" xsi:type="object">HawkSearch\EsIndexing\Model\Indexing\Entity\Hierarchy\ItemsDataProvider</argument>
-            <argument name="attributeHandler" xsi:type="object">HawkSearch\EsIndexing\Model\Hierarchy\Attribute\Handler\Composite</argument>
+            <!--
+            @deprecated 0.7.0 parameter value will be changed
+            @see HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\Composite
+            @todo Replace by HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\Composite type after ending the deprecation period
+            -->
+            <argument name="fieldHandler" xsi:type="object">HawkSearch\EsIndexing\Model\Hierarchy\Attribute\Handler\Composite</argument>
+            <!--<argument name="fieldHandler" xsi:type="object">HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\Composite</argument>-->
             <argument name="configHelper" xsi:type="object">HawkSearch\EsIndexing\Model\Indexing\Entity\Hierarchy\ConfigHelper</argument>
             <argument name="itemsIndexer" xsi:type="object">HawkSearch\EsIndexing\Model\Indexing\ItemsIndexer\HierarchyItemsIndexer</argument>
             <argument name="typeName" xsi:type="const">HawkSearch\EsIndexing\Model\Indexing\EntityType\HierarchyEntityType::ENTITY_TYPE_NAME</argument>
@@ -837,7 +845,13 @@
         <arguments>
             <argument name="rebuilder" xsi:type="object">HawkSearch\EsIndexing\Model\Indexing\Entity\Product\EntityRebuild\Proxy</argument>
             <argument name="itemsDataProvider" xsi:type="object">HawkSearch\EsIndexing\Model\Indexing\Entity\Product\ItemsDataProvider</argument>
-            <argument name="attributeHandler" shared="false" xsi:type="object">HawkSearch\EsIndexing\Model\Product\Attribute\Handler\Composite</argument>
+            <!--
+            @deprecated 0.7.0 parameter value will be changed
+            @see HawkSearch\EsIndexing\Model\Product\Field\Handler\Composite
+            @todo Replace by HawkSearch\EsIndexing\Model\Product\Field\Handler\Composite type after ending the deprecation period
+            -->
+            <argument name="fieldHandler" shared="false" xsi:type="object">HawkSearch\EsIndexing\Model\Product\Attribute\Handler\Composite</argument>
+            <!--<argument name="fieldHandler" shared="false" xsi:type="object">HawkSearch\EsIndexing\Model\Product\Field\Handler\Composite</argument>-->
             <argument name="configHelper" xsi:type="object">HawkSearch\EsIndexing\Model\Indexing\Entity\Product\ConfigHelper</argument>
             <argument name="itemsIndexer" xsi:type="object">HawkSearch\EsIndexing\Model\Indexing\ItemsIndexer\SearchedItemsIndexer</argument>
             <argument name="typeName" xsi:type="const">HawkSearch\EsIndexing\Model\Indexing\EntityType\ProductEntityType::ENTITY_TYPE_NAME</argument>
@@ -848,7 +862,13 @@
         <arguments>
             <argument name="rebuilder" xsi:type="object">HawkSearch\EsIndexing\Model\Indexing\Entity\ContentPage\EntityRebuild\Proxy</argument>
             <argument name="itemsDataProvider" xsi:type="object">HawkSearch\EsIndexing\Model\Indexing\Entity\ContentPage\ItemsDataProvider</argument>
-            <argument name="attributeHandler" xsi:type="object">HawkSearch\EsIndexing\Model\ContentPage\Attribute\Handler\Composite</argument>
+            <!--
+            @deprecated 0.7.0 parameter value will be changed
+            @see HawkSearch\EsIndexing\Model\ContentPage\Field\Handler\Composite
+            @todo Replace by HawkSearch\EsIndexing\Model\ContentPage\Field\Handler\Composite type after ending the deprecation period
+            -->
+            <argument name="fieldHandler" xsi:type="object">HawkSearch\EsIndexing\Model\ContentPage\Attribute\Handler\Composite</argument>
+            <!--<argument name="fieldHandler" xsi:type="object">HawkSearch\EsIndexing\Model\ContentPage\Field\Handler\Composite</argument>-->
             <argument name="configHelper" xsi:type="object">HawkSearch\EsIndexing\Model\Indexing\Entity\ContentPage\ConfigHelper</argument>
             <argument name="itemsIndexer" xsi:type="object">HawkSearch\EsIndexing\Model\Indexing\ItemsIndexer\SearchedItemsIndexer</argument>
             <argument name="typeName" xsi:type="const">HawkSearch\EsIndexing\Model\Indexing\EntityType\ContentPageEntityType::ENTITY_TYPE_NAME</argument>
@@ -859,7 +879,13 @@
         <arguments>
             <argument name="rebuilder" xsi:type="object">HawkSearch\EsIndexing\Model\Indexing\Entity\LandingPage\EntityRebuild\Proxy</argument>
             <argument name="itemsDataProvider" xsi:type="object">HawkSearch\EsIndexing\Model\Indexing\Entity\LandingPage\ItemsDataProvider</argument>
-            <argument name="attributeHandler" xsi:type="object">HawkSearch\EsIndexing\Model\LandingPage\Attribute\Handler\Composite</argument>
+            <!--
+            @deprecated 0.7.0 parameter value will be changed
+            @see HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\Composite
+            @todo Replace by HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\Composite type after ending the deprecation period
+            -->
+            <argument name="fieldHandler" xsi:type="object">HawkSearch\EsIndexing\Model\LandingPage\Attribute\Handler\Composite</argument>
+            <!--<argument name="fieldHandler" xsi:type="object">HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\Composite</argument>-->
             <argument name="configHelper" xsi:type="object">HawkSearch\EsIndexing\Model\Indexing\Entity\LandingPage\ConfigHelper</argument>
             <argument name="itemsIndexer" xsi:type="object">HawkSearch\EsIndexing\Model\Indexing\ItemsIndexer\LandingPageItemsIndexer</argument>
             <argument name="typeName" xsi:type="const">HawkSearch\EsIndexing\Model\Indexing\EntityType\LandingPageEntityType::ENTITY_TYPE_NAME</argument>
@@ -893,88 +919,122 @@
         </arguments>
     </type>
 
+    <!--
+    @deprecated 0.7.0 will be replaced by HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\Composite virtual type
+    @see HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\Composite
+     Move your type updates to HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\Composite virtual type.
+    -->
     <virtualType name="HawkSearch\EsIndexing\Model\Hierarchy\Attribute\Handler\Composite"
-                 type="HawkSearch\EsIndexing\Model\Indexing\AttributeHandler\Composite">
+                 type="HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\Composite"/>
+
+    <virtualType name="HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\Composite"
+                 type="HawkSearch\EsIndexing\Model\Indexing\FieldHandler\Composite">
         <arguments>
             <argument name="handlers" xsi:type="array">
                 <item name="hierarchy_id" xsi:type="array">
                     <item name="attribute" xsi:type="const">HawkSearch\EsIndexing\Api\Data\HierarchyInterface::FIELD_HIERARCHY_ID</item>
-                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\Hierarchy\Attribute\Handler\HierarchyId</item>
+                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\HierarchyId</item>
                 </item>
                 <item name="name" xsi:type="array">
                     <item name="attribute" xsi:type="const">HawkSearch\EsIndexing\Api\Data\HierarchyInterface::FIELD_NAME</item>
-                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\Hierarchy\Attribute\Handler\Name</item>
+                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\Name</item>
                 </item>
                 <item name="parent_hierarchy_id" xsi:type="array">
                     <item name="attribute" xsi:type="const">HawkSearch\EsIndexing\Api\Data\HierarchyInterface::FIELD_PARENT_HIERARCHY_ID</item>
-                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\Hierarchy\Attribute\Handler\ParentHierarchyId</item>
+                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\ParentHierarchyId</item>
                 </item>
                 <item name="is_active" xsi:type="array">
                     <item name="attribute" xsi:type="const">HawkSearch\EsIndexing\Api\Data\HierarchyInterface::FIELD_IS_ACTIVE</item>
-                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\Hierarchy\Attribute\Handler\IsActive</item>
+                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\IsActive</item>
                 </item>
             </argument>
         </arguments>
     </virtualType>
 
+    <!--
+    @deprecated 0.7.0 will be replaced by HawkSearch\EsIndexing\Model\ContentPage\Field\Handler\Composite virtual type
+    @see HawkSearch\EsIndexing\Model\ContentPage\Field\Handler\Composite
+     Move your type updates to HawkSearch\EsIndexing\Model\ContentPage\Field\Handler\Composite virtual type.
+    -->
     <virtualType name="HawkSearch\EsIndexing\Model\ContentPage\Attribute\Handler\Composite"
-                 type="HawkSearch\EsIndexing\Model\Indexing\AttributeHandler\Composite">
+                 type="HawkSearch\EsIndexing\Model\ContentPage\Field\Handler\Composite" />
+
+    <virtualType name="HawkSearch\EsIndexing\Model\ContentPage\Field\Handler\Composite"
+                 type="HawkSearch\EsIndexing\Model\Indexing\FieldHandler\Composite">
         <arguments>
             <argument name="handlers" xsi:type="array">
                 <item name="url" xsi:type="array">
                     <item name="attribute" xsi:type="string">url</item>
-                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\ContentPage\Attribute\Handler\Url</item>
+                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\ContentPage\Field\Handler\Url</item>
                 </item>
             </argument>
         </arguments>
     </virtualType>
 
+    <!--
+    @deprecated 0.7.0 will be replaced by HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\Composite virtual type
+    @see HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\Composite
+     Move your type updates to HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\Composite virtual type.
+    -->
     <virtualType name="HawkSearch\EsIndexing\Model\LandingPage\Attribute\Handler\Composite"
-                 type="HawkSearch\EsIndexing\Model\Indexing\AttributeHandler\Composite">
+                 type="HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\Composite" />
+
+    <virtualType name="HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\Composite"
+                 type="HawkSearch\EsIndexing\Model\Indexing\FieldHandler\Composite">
         <arguments>
             <argument name="handlers" xsi:type="array">
                 <item name="name" xsi:type="array">
-                    <item name="attribute" xsi:type="const">HawkSearch\EsIndexing\Model\Indexing\AttributeHandler\Composite::HANDLER_DEFAULT_NAME</item>
-                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\LandingPage\Attribute\Handler\DefaultHandler</item>
+                    <item name="attribute" xsi:type="const">HawkSearch\EsIndexing\Model\Indexing\FieldHandler\Composite::HANDLER_DEFAULT_NAME</item>
+                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\DefaultHandler</item>
                 </item>
                 <item name="custom_url" xsi:type="array">
                     <item name="attribute" xsi:type="const">HawkSearch\EsIndexing\Api\Data\LandingPageInterface::FIELD_CUSTOM_URL</item>
-                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\LandingPage\Attribute\Handler\CustomUrl</item>
+                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\CustomUrl</item>
                 </item>
                 <item name="narrow_xml" xsi:type="array">
                     <item name="attribute" xsi:type="const">HawkSearch\EsIndexing\Api\Data\LandingPageInterface::FIELD_NARROW_XML</item>
-                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\LandingPage\Attribute\Handler\NarrowXml</item>
+                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\NarrowXml</item>
                 </item>
                 <item name="custom_sort_list" xsi:type="array">
                     <item name="attribute" xsi:type="const">HawkSearch\EsIndexing\Api\Data\LandingPageInterface::FIELD_CUSTOM_SORT_LIST</item>
-                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\LandingPage\Attribute\Handler\CustomSortList</item>
+                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\CustomSortList</item>
                 </item>
             </argument>
         </arguments>
     </virtualType>
 
+    <!--
+    @deprecated 0.7.0 will be replaced by HawkSearch\EsIndexing\Model\Product\Field\Handler\Composite type
+    @see HawkSearch\EsIndexing\Model\Product\Field\Handler\Composite
+    Move your type updates to HawkSearch\EsIndexing\Model\Product\Field\Handler\Composite
+    -->
     <type name="HawkSearch\EsIndexing\Model\Product\Attribute\Handler\Composite">
+        <!--
+        Arguments definition has been moved to HawkSearch\EsIndexing\Model\Product\Field\Handler\Composite
+        -->
+    </type>
+    <type name="HawkSearch\EsIndexing\Model\Product\Field\Handler\Composite">
         <arguments>
             <argument name="handlers" xsi:type="array">
                 <item name="name" xsi:type="array">
-                    <item name="attribute" xsi:type="const">HawkSearch\EsIndexing\Model\Indexing\AttributeHandler\Composite::HANDLER_DEFAULT_NAME</item>
-                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\Product\Attribute\Handler\DefaultHandler</item>
+                    <item name="attribute" xsi:type="const">HawkSearch\EsIndexing\Model\Indexing\FieldHandler\Composite::HANDLER_DEFAULT_NAME</item>
+                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\Product\Field\Handler\DefaultHandler</item>
                 </item>
                 <item name="url" xsi:type="array">
                     <item name="attribute" xsi:type="string">url</item>
-                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\Product\Attribute\Handler\Url</item>
+                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\Product\Field\Handler\Url</item>
                 </item>
                 <item name="thumbnail_url" xsi:type="array">
                     <item name="attribute" xsi:type="string">thumbnail_url</item>
-                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\Product\Attribute\Handler\ImageUrl</item>
+                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\Product\Field\Handler\ImageUrl</item>
                 </item>
                 <item name="image_url" xsi:type="array">
                     <item name="attribute" xsi:type="string">image_url</item>
-                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\Product\Attribute\Handler\ImageUrl</item>
+                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\Product\Field\Handler\ImageUrl</item>
                 </item>
                 <item name="category" xsi:type="array">
                     <item name="attribute" xsi:type="string">category</item>
-                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\Product\Attribute\Handler\Category</item>
+                    <item name="class" xsi:type="string">HawkSearch\EsIndexing\Model\Product\Field\Handler\Category</item>
                 </item>
             </argument>
             <argument name="childrenItemsDataProvider" xsi:type="object">HawkSearch\EsIndexing\Model\Indexing\Entity\Product\ChildrenItemsDataProvider</argument>


### PR DESCRIPTION
[feat: deprecate AttributeHandlerInterface, add FieldHandlerInterface](https://github.com/hawksearch/esindexing-magento-2/commit/17f661d216085a7772d54d0ab28c85d301eb7770) 

Class changes:
- Model\ContentPage\Attribute\Handler\Url is deprecated,
  use Model\ContentPage\Field\Handler\Url
- Model\Hierarchy\Attribute\Handler\HierarchyId is deprecated,
  use Model\Hierarchy\Field\Handler\HierarchyId
- Model\Hierarchy\Attribute\Handler\IsActive is deprecated,
  use Model\Hierarchy\Field\Handler\IsActive
- Model\Hierarchy\Attribute\Handler\Name is deprecated,
  use Model\Hierarchy\Field\Handler\Name
- Model\Hierarchy\Attribute\Handler\ParentHierarchyId is deprecated,
  use Model\Hierarchy\Field\Handler\ParentHierarchyId
- Model\Indexing\AttributeHandler\Composite is deprecated,
  use Model\Indexing\FieldHandler\Composite
- Model\Indexing\AttributeHandler\DataObjectHandler is deprecated,
  use Model\Indexing\FieldHandler\DataObjectHandler
- Model\LandingPage\Attribute\Handler\CustomSortList is deprecated,
  use Model\LandingPage\Field\Handler\CustomSortList
- Model\LandingPage\Attribute\Handler\CustomUrl is deprecated,
  use Model\LandingPage\Field\Handler\CustomUrl
- Model\LandingPage\Attribute\Handler\DefaultHandler is deprecated,
  use Model\LandingPage\Field\Handler\DefaultHandler
- Model\LandingPage\Attribute\Handler\NarrowXml is deprecated,
  use Model\LandingPage\Field\Handler\NarrowXml
- Model\Product\Attribute\Handler\Category is deprecated,
  use Model\Product\Field\Handler\Category
- Model\Product\Attribute\Handler\Composite is deprecated,
  use Model\Product\Field\Handler\Composite
- Model\Product\Attribute\Handler\DefaultHandler is deprecated,
  use Model\Product\Field\Handler\DefaultHandler
- Model\Product\Attribute\Handler\ImageUrl is deprecated,
  use Model\Product\Field\Handler\ImageUrl
- Model\Product\Attribute\Handler\Url is deprecated,
  use Model\Product\Field\Handler\Url
- Parameter $attributeHandler is deprecated in method
  HawkSearch\EsIndexing\Model\Indexing\EntityType::__construct(),
  use $fieldHandler
- HawkSearch\EsIndexing\Model\Indexing\EntityType\EntityTypeAbstract::getAttributeHandler()
  is deprecated,
  use HawkSearch\EsIndexing\Model\Indexing\EntityType\EntityTypeAbstract::getFieldHandler()

Interface changes:
- HawkSearch\EsIndexing\Model\Indexing\AttributeHandlerInterface is
  deprecated,
  use HawkSearch\EsIndexing\Model\Indexing\FieldHandlerInterface
- HawkSearch\EsIndexing\Model\Indexing\EntityTypeInterface::getAttributeHandler()
  is deprecated,
  use HawkSearch\EsIndexing\Model\Indexing\EntityTypeInterface::getFieldHandler()

Di changes:
- HawkSearch\EsIndexing\Model\Hierarchy\Attribute\Handler\Composite virtual type is deprecated
  use HawkSearch\EsIndexing\Model\Hierarchy\Field\Handler\Composite
- HawkSearch\EsIndexing\Model\ContentPage\Attribute\Handler\Composite virtual type is deprecated
  use HawkSearch\EsIndexing\Model\ContentPage\Field\Handler\Composite
- HawkSearch\EsIndexing\Model\LandingPage\Attribute\Handler\Composite virtual type is deprecated
  use HawkSearch\EsIndexing\Model\LandingPage\Field\Handler\Composite

[feat: add visibility_search, visibility_catalog fields](https://github.com/hawksearch/esindexing-magento-2/commit/4bec7a6b5e9441237f10e483a61d1ae0d70324d9)

Field visibility has been replaced by visibility_search, visibility_catalog fields

Ref: HC-1572, HC-1639

[fix: name category attribute is not added to collection](https://github.com/hawksearch/esindexing-magento-2/commit/34548ad27acd71152f15268c89aaa9528c556946)

When EAV category collection is used, then name attribute is not added to
selected attributes. As a result Category facet displays category ID's
instead of Nams (based on Hierarchy API). Landing pages API also breaks
on reindexing.

[feat: add field specific search for product visibility](https://github.com/hawksearch/esindexing-magento-2/commit/1cacc6c4efb97688cb4f025a21e2973959cb170b)

visibility_search:true Query condition is used for main search request.
visibility_catalog:true Query condition is used for category pages requests.

Ref: HC-1572, HC-1638