### PR TITLE
fix: top categories links in AC redirect

### DIFF
--- a/Plugin/CatalogSearch/ResultIndexPlugin.php
+++ b/Plugin/CatalogSearch/ResultIndexPlugin.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Plugin\CatalogSearch;
+
+use HawkSearch\EsIndexing\Model\Config\Search as SearchConfig;
+use Magento\CatalogSearch\Controller\Result\Index;
+use Magento\CatalogSearch\Helper\Data as CatalogSearchHelper;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\App\ViewInterface;
+use Magento\Search\Model\QueryFactory;
+
+class ResultIndexPlugin
+{
+    /**
+     * @var QueryFactory
+     */
+    private QueryFactory $queryFactory;
+
+    /**
+     * @var ViewInterface
+     */
+    private ViewInterface $view;
+
+    /**
+     * @var SearchConfig
+     */
+    private SearchConfig $searchConfig;
+
+    /**
+     * @param QueryFactory $queryFactory
+     * @param ViewInterface $view
+     * @param SearchConfig $searchConfig
+     */
+    public function __construct(
+        QueryFactory $queryFactory,
+        ViewInterface $view,
+        SearchConfig $searchConfig
+    )
+    {
+        $this->queryFactory = $queryFactory;
+        $this->view = $view;
+        $this->searchConfig = $searchConfig;
+    }
+
+    /**
+     * @param Index $subject
+     * @param null $result
+     * @return void
+     */
+    public function afterExecute(Index $subject, $result): void
+    {
+        if (!$this->searchConfig->isSearchEnabled()) {
+            return;
+        }
+
+        $catalogSearchHelper = ObjectManager::getInstance()->get(CatalogSearchHelper::class);
+
+        $query = $this->queryFactory->get();
+        if ($query->getQueryText() == '') {
+            if ($subject->getResponse()->getHeader('Location')) {
+                $subject->getResponse()->clearHeader('Location');
+                $subject->getResponse()->setHttpResponseCode(200);
+
+                $catalogSearchHelper->checkNotes();
+
+                $this->view->loadLayout();
+                $subject->getResponse()->setNoCacheHeaders();
+                $this->view->renderLayout();
+            }
+        }
+    }
+}

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -114,5 +114,9 @@
     <type name="Magento\Checkout\CustomerData\Cart">
         <plugin name="hawksearch_tracking_price_data" type="HawkSearch\EsIndexing\Plugin\Checkout\CustomerData\Cart"/>
     </type>
+    <type name="Magento\CatalogSearch\Controller\Result\Index">
+        <plugin name="hawksearch_allow_empty_query"
+                type="HawkSearch\EsIndexing\Plugin\CatalogSearch\ResultIndexPlugin"/>
+    </type>
     <!-- END Plugins -->
 </config>


### PR DESCRIPTION
Links in Top Categories block in autocomplete has no 'q' parameter in the URL. It redirects all these links to home page because Magento doesn't allow Search Results page URL without 'q' parameter. This update changes the default logic of Magento and allows Search Results page to be opened without 'q' parameter accessing all results from the Hawksearch index.