### PR TITLE
fix: skip loading reviews data

### DIFF
--- a/Model/Api/SearchCriteria/JoinProcessor/ReviewRatingSummary.php
+++ b/Model/Api/SearchCriteria/JoinProcessor/ReviewRatingSummary.php
@@ -69,10 +69,16 @@ class ReviewRatingSummary implements CustomJoinInterface
         }
 
         //TODO: check if review_summary attribute is selected for indexing
-        $this->sumResourceFactory->create()->appendSummaryFieldsToCollection(
-            $collection,
-            $storeId,
-            \Magento\Review\Model\Review::ENTITY_PRODUCT_CODE
-        );
+        //TODO: push reviews data to the index https://bridgeline.atlassian.net/browse/HC-1693
+        //Since we do not push reviews data to the index yet disable data collecting as well
+        $addReviewData = false;
+
+        if ($addReviewData) {
+            $this->sumResourceFactory->create()->appendSummaryFieldsToCollection(
+                $collection,
+                $storeId,
+                \Magento\Review\Model\Review::ENTITY_PRODUCT_CODE
+            );
+        }
     }
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -128,6 +128,10 @@
                         ]]>
                     </comment>
                 </field>
+                <!--<field id="add_reviews_data" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Add reviews data</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>-->
 
             </group>
         </section>


### PR DESCRIPTION
Reviews data isn't sent to the index yet (not implemented), but reviews data is loading to the final product collection.