### PR TITLE
fix: loading the entire product collection when there are no children

### DIFF
--- a/Model/Indexing/Entity/Product/ItemsDataProvider.php
+++ b/Model/Indexing/Entity/Product/ItemsDataProvider.php
@@ -230,14 +230,16 @@ class ItemsDataProvider implements ItemsDataProviderInterface
             return;
         }
 
+        $childrenMap = $this->productDataProvider->getChildrenByParentMap(array_keys($products));
+        if (!count($childrenMap)) {
+            return;
+        }
+
+        $this->searchCriteriaBuilder->addFilter('entity_id', array_merge([], ...$childrenMap), 'in');
+
         $currentProduct = current($products);
         $storeId = $currentProduct->getStoreId();
         $this->searchCriteriaBuilder->addFilter('store_id', $storeId);
-
-        $childrenMap = $this->productDataProvider->getChildrenByParentMap(array_keys($products));
-        if (count($childrenMap) > 0) {
-            $this->searchCriteriaBuilder->addFilter('entity_id', array_merge([], ...$childrenMap), 'in');
-        }
 
         $children = $this->getProductItems($this->searchCriteriaBuilder->create());
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -124,7 +124,9 @@
                     <backend_model>HawkSearch\EsIndexing\Model\Config\Backend\Serialized\ProductAttributes</backend_model>
                     <comment>
                         <![CDATA[
-                            Specify product attributes.
+                            Specify product attributes users can search on, use for facets and sorting. Every Magento attribute should be mapped to a HawkSearch field.
+                            On configuration saving HawkSearch fields are synced with some Magento attribute properties. Learn more about syncing in
+                            <a href="https://developerdocs.hawksearch.com/docs/magento-indexing#fields--attributes">Fields & Attributes</a> documentation
                         ]]>
                     </comment>
                 </field>


### PR DESCRIPTION
This was a huge performance downside for any chunk which has
only simple products (no children). For such chunks there were
a performance degradation because of loading a full product collection.

Ref: HC-1687, HC-1686

[docs: update Attributes config comment](https://github.com/hawksearch/esindexing-magento-2/commit/523def6b206d4ec15180ae3b2d922257268bcd52)