### PR TITLE
Hotfix 0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 See tasks currently in development on [Unreleased] changes page.
 
+
+## [0.7.3] - 2024-10-02
+A performance update for product indexing. Due to some bugs in release 0.7.0 the performance in some edge cases was dramatically decreased.
+
+### FIXES
+* **fix: skip loading reviews data** [#73](https://github.com/hawksearch/esindexing-magento-2/pull/73)
+* **fix: loading the entire product collection when there are no children** [#74](https://github.com/hawksearch/esindexing-magento-2/pull/74)
+  This was a huge performance downside for any chunk which has
+  only simple products (no children). For such chunks there were
+  a performance degradation because of loading a full product collection.
+  Ref: HC-1687, HC-1686
+* **perf: do not load total product collection size** [#75](https://github.com/hawksearch/esindexing-magento-2/pull/75)
+* **perf: add only specific attributes to product collection** [#76](https://github.com/hawksearch/esindexing-magento-2/pull/76)
+  When product collection is loading all available product attributes are added to collection. This fix makes it loading only attributes
+  which are configured in Field-Attribute mapping configuration
+  Ref: HC-1689
+* **perf: optimize indexer:reindex command** [#78](https://github.com/hawksearch/esindexing-magento-2/pull/78)
+  Optimize product collection loading when `bin/magento indexer:reindex` command is executed. Avoid loading useless data because index scheduler just requires to know the collection size.
+  Ref: HC-1690
+* **fix: send sku field to index by default** [#79](https://github.com/hawksearch/esindexing-magento-2/pull/79)
+  Ref: HC-1695
+
+
 ## [0.7.2] - 2024-08-23
 
 ### FIXES
@@ -460,7 +483,8 @@ __fix: minimal compatible version of connector package is 2.8.0__ ([#45](https:/
 ## 0.1.0
 Initial stable release
 
-[Unreleased]: https://github.com/hawksearch/esindexing-magento-2/compare/v0.7.2...HEAD
+[Unreleased]: https://github.com/hawksearch/esindexing-magento-2/compare/v0.7.3...HEAD
+[0.7.3]: https://github.com/hawksearch/esindexing-magento-2/compare/v0.7.2...v0.7.3
 [0.7.2]: https://github.com/hawksearch/esindexing-magento-2/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/hawksearch/esindexing-magento-2/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/hawksearch/esindexing-magento-2/compare/v0.6.4...v0.7.0

--- a/Model/Api/SearchCriteria/JoinProcessor/CleanAttributes.php
+++ b/Model/Api/SearchCriteria/JoinProcessor/CleanAttributes.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Model\Api\SearchCriteria\JoinProcessor;
+
+use Magento\Eav\Model\Entity\Collection\AbstractCollection;
+use Magento\Framework\Api\SearchCriteria\CollectionProcessor\JoinProcessor\CustomJoinInterface;
+use Magento\Framework\Data\Collection\AbstractDb;
+
+/**
+ * Clean all selected attributes in collection.
+ */
+class CleanAttributes implements CustomJoinInterface
+{
+    /**
+     * @inheritDoc
+     * @param AbstractCollection $collection
+     */
+    public function apply(AbstractDb $collection)
+    {
+        $collection->removeAttributeToSelect();
+    }
+}

--- a/Model/Api/SearchCriteria/JoinProcessor/ProductMainAttributes.php
+++ b/Model/Api/SearchCriteria/JoinProcessor/ProductMainAttributes.php
@@ -15,12 +15,22 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\Api\SearchCriteria\JoinProcessor;
 
+use HawkSearch\EsIndexing\Model\Product\Attributes;
 use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollection;
 use Magento\Framework\Api\SearchCriteria\CollectionProcessor\JoinProcessor\CustomJoinInterface;
 use Magento\Framework\Data\Collection\AbstractDb;
 
+/**
+ * Add only specific attribute to entities in collection.
+ */
 class ProductMainAttributes implements CustomJoinInterface
 {
+    private Attributes $attributes;
+
+    public function __construct(Attributes $attributes)
+    {
+        $this->attributes = $attributes;
+    }
 
     /**
      * @inheritDoc
@@ -28,16 +38,7 @@ class ProductMainAttributes implements CustomJoinInterface
      */
     public function apply(AbstractDb $collection)
     {
-        /*$collection->addAttributeToSelect('name')
-            ->addAttributeToSelect('url_key')
-            ->addAttributeToSelect('image')
-            ->addAttributeToSelect('small_image')
-            ->addAttributeToSelect('thumbnail')
-            ->addAttributeToSelect('msrp')
-            ->addAttributeToSelect('msrp_enabled')
-            ->addAttributeToSelect('short_description')
-            ->addAttributeToSelect('description')
-            ->addAttributeToSelect('meta_keyword')
-            ->addAttributeToSelect('qty');*/
+        $collection->removeAttributeToSelect();
+        $collection->addAttributeToSelect($this->attributes->getIndexedAttributes());
     }
 }

--- a/Model/Api/SearchCriteria/JoinProcessor/ProductMainAttributes.php
+++ b/Model/Api/SearchCriteria/JoinProcessor/ProductMainAttributes.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2022 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/Model/Api/SearchCriteria/JoinProcessor/ProductPrices.php
+++ b/Model/Api/SearchCriteria/JoinProcessor/ProductPrices.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2022 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/Model/Api/SearchCriteria/JoinProcessor/ReviewRatingSummary.php
+++ b/Model/Api/SearchCriteria/JoinProcessor/ReviewRatingSummary.php
@@ -69,10 +69,16 @@ class ReviewRatingSummary implements CustomJoinInterface
         }
 
         //TODO: check if review_summary attribute is selected for indexing
-        $this->sumResourceFactory->create()->appendSummaryFieldsToCollection(
-            $collection,
-            $storeId,
-            \Magento\Review\Model\Review::ENTITY_PRODUCT_CODE
-        );
+        //TODO: push reviews data to the index https://bridgeline.atlassian.net/browse/HC-1693
+        //Since we do not push reviews data to the index yet disable data collecting as well
+        $addReviewData = false;
+
+        if ($addReviewData) {
+            $this->sumResourceFactory->create()->appendSummaryFieldsToCollection(
+                $collection,
+                $storeId,
+                \Magento\Review\Model\Review::ENTITY_PRODUCT_CODE
+            );
+        }
     }
 }

--- a/Model/Api/SearchCriteria/JoinProcessor/ReviewRatingSummary.php
+++ b/Model/Api/SearchCriteria/JoinProcessor/ReviewRatingSummary.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2022 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/Model/Api/SearchCriteria/JoinProcessor/SkipCategoryIds.php
+++ b/Model/Api/SearchCriteria/JoinProcessor/SkipCategoryIds.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Model\Api\SearchCriteria\JoinProcessor;
+
+use Magento\Eav\Model\Entity\Collection\AbstractCollection;
+use Magento\Framework\Api\SearchCriteria\CollectionProcessor\JoinProcessor\CustomJoinInterface;
+use Magento\Framework\Data\Collection\AbstractDb;
+
+/**
+ * Skip loading category_ids attribute to product collection
+ */
+class SkipCategoryIds implements CustomJoinInterface
+{
+    /**
+     * @inheritDoc
+     * @param AbstractCollection $collection
+     */
+    public function apply(AbstractDb $collection)
+    {
+        $collection->setFlag('category_ids_added', true);
+    }
+}

--- a/Model/Indexing/Entity/Product/ItemsDataProvider.php
+++ b/Model/Indexing/Entity/Product/ItemsDataProvider.php
@@ -230,14 +230,16 @@ class ItemsDataProvider implements ItemsDataProviderInterface
             return;
         }
 
+        $childrenMap = $this->productDataProvider->getChildrenByParentMap(array_keys($products));
+        if (!count($childrenMap)) {
+            return;
+        }
+
+        $this->searchCriteriaBuilder->addFilter('entity_id', array_merge([], ...$childrenMap), 'in');
+
         $currentProduct = current($products);
         $storeId = $currentProduct->getStoreId();
         $this->searchCriteriaBuilder->addFilter('store_id', $storeId);
-
-        $childrenMap = $this->productDataProvider->getChildrenByParentMap(array_keys($products));
-        if (count($childrenMap) > 0) {
-            $this->searchCriteriaBuilder->addFilter('entity_id', array_merge([], ...$childrenMap), 'in');
-        }
 
         $children = $this->getProductItems($this->searchCriteriaBuilder->create());
 

--- a/Model/Indexing/Entity/Product/Scheduler/ItemsDataProvider.php
+++ b/Model/Indexing/Entity/Product/Scheduler/ItemsDataProvider.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Model\Indexing\Entity\Product\Scheduler;
+
+class ItemsDataProvider extends \HawkSearch\EsIndexing\Model\Indexing\Entity\Product\ItemsDataProvider
+{
+    public function getItems($storeId, $entityIds = null, $currentPage = 1, $pageSize = 0)
+    {
+        return $this->getProductCollection($storeId, $entityIds, $currentPage, $pageSize);
+    }
+}

--- a/Model/Product/Attributes.php
+++ b/Model/Product/Attributes.php
@@ -111,6 +111,7 @@ class Attributes
             'thumbnail_url' => 'thumbnail_url',
             'image_url' => 'image_url',
             'name' => 'name',
+            'sku' => 'sku',
             'category' => '',
             'url' => '',
             'visibility_search' => '',

--- a/Model/ResourceModel/Product/Collection.php
+++ b/Model/ResourceModel/Product/Collection.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Model\ResourceModel\Product;
+
+/**
+ * Class stub used for disabling plugin
+ * For performance reasons we disable methods which collect total size of the entire collection.
+ * For huge catalogs getting the total collection size is a performance degradation point.
+ * We don't use the total collection size ever, so it is safe to disable it's collecting.
+ */
+class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
+{
+    /*
+     * We don't need total collection size
+     */
+    public function getSize()
+    {
+        return 0;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Check out our [Getting Started](https://developerdocs.hawksearch.com/docs/magent
 
 ## Platform Version Support
 
-* Magento Open Source: 2.4.0 - 2.4.6
-* Adobe Commerce: 2.4.0 - 2.4.6
+* Magento Open Source: 2.4.0 - 2.4.7
+* Adobe Commerce: 2.4.0 - 2.4.7
 
 ## Installation Instructions
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "license": "proprietary",
     "description": "Hawksearch ES Indexing module for Magento Open Source and Adobe Commerce",
     "type": "magento2-module",
-    "version": "0.7.2",
+    "version": "0.7.3",
     "require": {
         "magento/framework": "^103.0",
         "magento/module-asynchronous-operations": "~100.3",

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -124,7 +124,9 @@
                     <backend_model>HawkSearch\EsIndexing\Model\Config\Backend\Serialized\ProductAttributes</backend_model>
                     <comment>
                         <![CDATA[
-                            Specify product attributes.
+                            Specify product attributes users can search on, use for facets and sorting. Every Magento attribute should be mapped to a HawkSearch field.
+                            On configuration saving HawkSearch fields are synced with some Magento attribute properties. Learn more about syncing in
+                            <a href="https://developerdocs.hawksearch.com/docs/magento-indexing#fields--attributes">Fields & Attributes</a> documentation
                         ]]>
                     </comment>
                 </field>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -128,6 +128,10 @@
                         ]]>
                     </comment>
                 </field>
+                <!--<field id="add_reviews_data" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Add reviews data</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>-->
 
             </group>
         </section>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1303,10 +1303,45 @@
         </arguments>
     </virtualType>
 
+    <virtualType name="HawkSearch\EsIndexing\Model\Indexing\EntityType\Scheduler\ProductEntityType"
+                 type="HawkSearch\EsIndexing\Model\Indexing\EntityType\ProductEntityType">
+        <arguments>
+            <argument name="itemsDataProvider" xsi:type="object">HawkSearch\EsIndexing\Model\Indexing\Entity\Product\Scheduler\ItemsDataProvider</argument>
+        </arguments>
+    </virtualType>
+    <type name="HawkSearch\EsIndexing\Model\Indexing\Entity\Product\Scheduler\ItemsDataProvider">
+        <arguments>
+            <argument name="productRepository" xsi:type="object">HawkSearch\EsIndexing\Model\Indexing\Entity\Product\Scheduler\ProductRepository</argument>
+        </arguments>
+    </type>
+    <virtualType name="HawkSearch\EsIndexing\Model\Indexing\Entity\Product\Scheduler\ProductRepository" type="Magento\Catalog\Model\ProductRepository">
+        <arguments>
+            <argument name="collectionProcessor" xsi:type="object">HawkSearch\EsIndexing\Model\Api\SearchCriteria\Scheduler\ProductCollectionProcessor</argument>
+            <argument name="readExtensions" xsi:type="object">HawkSearch\EsIndexing\Product\EntityManager\Operation\Read\ReadExtensions</argument>
+            <argument name="collectionFactory" xsi:type="object">HawkSearch\EsIndexing\Model\ResourceModel\Product\CollectionFactory</argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="HawkSearch\EsIndexing\Model\Api\SearchCriteria\Scheduler\ProductCollectionProcessor"
+                 type="Magento\Catalog\Model\Api\SearchCriteria\ProductCollectionProcessor">
+        <arguments>
+            <argument name="processors" xsi:type="array">
+                <item name="joins" xsi:type="object">HawkSearch\EsIndexing\Model\Api\SearchCriteria\Scheduler\CollectionProcessor\ProductItemsJoinProcessor</item>
+            </argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="HawkSearch\EsIndexing\Model\Api\SearchCriteria\Scheduler\CollectionProcessor\ProductItemsJoinProcessor"
+                 type="HawkSearch\EsIndexing\Model\Api\SearchCriteria\CollectionProcessor\CustomJoinProcessor">
+        <arguments>
+            <argument name="customJoins" xsi:type="array">
+                <item name="clean_attributes" xsi:type="object">HawkSearch\EsIndexing\Model\Api\SearchCriteria\JoinProcessor\CleanAttributes</item>
+                <item name="skip_cetegory_ids" xsi:type="object">HawkSearch\EsIndexing\Model\Api\SearchCriteria\JoinProcessor\SkipCategoryIds</item>
+            </argument>
+        </arguments>
+    </virtualType>
     <virtualType name="HawkSearch\EsIndexing\Model\Indexer\Entities\Scheduler\Product"
                  type="HawkSearch\EsIndexing\Model\Indexer\Entities\SchedulerAbstract">
         <arguments>
-            <argument name="entityType" xsi:type="object">HawkSearch\EsIndexing\Model\Indexing\EntityType\ProductEntityType</argument>
+            <argument name="entityType" xsi:type="object">HawkSearch\EsIndexing\Model\Indexing\EntityType\Scheduler\ProductEntityType</argument>
         </arguments>
     </virtualType>
     <virtualType name="HawkSearch\EsIndexing\Model\Indexer\Entities\Scheduler\ContentPage"

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -818,6 +818,7 @@
                 <item name="price" xsi:type="object">HawkSearch\EsIndexing\Model\Api\SearchCriteria\JoinProcessor\ProductPrices</item>
                 <item name="review_summary" xsi:type="object">HawkSearch\EsIndexing\Model\Api\SearchCriteria\JoinProcessor\ReviewRatingSummary</item>
                 <item name="url_rewrites" xsi:type="object">HawkSearch\EsIndexing\Model\Api\SearchCriteria\JoinProcessor\UrlRewrites</item>
+                <item name="select_attributes" xsi:type="object">HawkSearch\EsIndexing\Model\Api\SearchCriteria\JoinProcessor\ProductMainAttributes</item>
             </argument>
         </arguments>
     </virtualType>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -800,6 +800,7 @@
         <arguments>
             <argument name="collectionProcessor" xsi:type="object">HawkSearch\EsIndexing\Model\Api\SearchCriteria\ProductCollectionProcessor</argument>
             <argument name="readExtensions" xsi:type="object">HawkSearch\EsIndexing\Product\EntityManager\Operation\Read\ReadExtensions</argument>
+            <argument name="collectionFactory" xsi:type="object">HawkSearch\EsIndexing\Model\ResourceModel\Product\CollectionFactory</argument>
         </arguments>
     </virtualType>
     <virtualType name="HawkSearch\EsIndexing\Model\Api\SearchCriteria\ProductCollectionProcessor"
@@ -825,6 +826,15 @@
             <argument name="extensionPool" xsi:type="object">HawkSearch\EsIndexing\Model\Product\EntityManager\Operation\ExtensionPool</argument>
         </arguments>
     </virtualType>
+    <virtualType name="HawkSearch\EsIndexing\Model\ResourceModel\Product\CollectionFactory" type="Magento\Catalog\Model\ResourceModel\Product\CollectionFactory">
+        <arguments>
+            <argument name="instanceName" xsi:type="string">HawkSearch\EsIndexing\Model\ResourceModel\Product\Collection</argument>
+        </arguments>
+    </virtualType>
+    <!--  For performance purposes we disable currentPageDetection plugin  because it causes loading count SQL for entire product collection -->
+    <type name="HawkSearch\EsIndexing\Model\ResourceModel\Product\Collection">
+        <plugin name="currentPageDetection" disabled="true" />
+    </type>
     <!-- END Product indexing repository -->
 
     <!-- Types and Plugins -->

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
   /**
-   * Copyright (c) 2022 Hawksearch (www.hawksearch.com) - All Rights Reserved
+   * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
    *
    * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
    * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -21,6 +21,7 @@
             <module name="Magento_Indexer"/>
             <module name="Magento_AsynchronousOperations"/>
             <module name="Magento_Checkout"/>
+            <module name="Magento_Theme"/>
         </sequence>
     </module>
 </config>


### PR DESCRIPTION
A performance update for product indexing. Due to some bugs in release 0.7.0 the performance in some edge cases was dramatically decreased. 

### FIXES
* **fix: skip loading reviews data** [#73](https://github.com/hawksearch/esindexing-magento-2/pull/73)
* **fix: loading the entire product collection when there are no children** [#74](https://github.com/hawksearch/esindexing-magento-2/pull/74)
  This was a huge performance downside for any chunk which has
  only simple products (no children). For such chunks there were
  a performance degradation because of loading a full product collection.
  Ref: HC-1687, HC-1686
* **perf: do not load total product collection size** [#75](https://github.com/hawksearch/esindexing-magento-2/pull/75)
* **perf: add only specific attributes to product collection** [#76](https://github.com/hawksearch/esindexing-magento-2/pull/76)
  When product collection is loading all available product attributes are added to collection. This fix makes it loading only attributes 
  which are configured in Field-Attribute mapping configuration
  Ref: HC-1689
* **perf: optimize indexer:reindex command** [#78](https://github.com/hawksearch/esindexing-magento-2/pull/78)
  Optimize product collection loading when `bin/magento indexer:reindex` command is executed. Avoid loading useless data because index scheduler just requires to know the collection size.
  Ref: HC-1690
* **fix: send sku field to index by default** [#79](https://github.com/hawksearch/esindexing-magento-2/pull/79)
  Ref: HC-1695


**Full Changelog**: https://github.com/hawksearch/esindexing-magento-2/compare/v0.7.2...v0.7.3