### PR TITLE
perf: optimize indexer:reindex command

### DIFF
--- a/Model/Api/SearchCriteria/JoinProcessor/CleanAttributes.php
+++ b/Model/Api/SearchCriteria/JoinProcessor/CleanAttributes.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Model\Api\SearchCriteria\JoinProcessor;
+
+use Magento\Eav\Model\Entity\Collection\AbstractCollection;
+use Magento\Framework\Api\SearchCriteria\CollectionProcessor\JoinProcessor\CustomJoinInterface;
+use Magento\Framework\Data\Collection\AbstractDb;
+
+/**
+ * Clean all selected attributes in collection.
+ */
+class CleanAttributes implements CustomJoinInterface
+{
+    /**
+     * @inheritDoc
+     * @param AbstractCollection $collection
+     */
+    public function apply(AbstractDb $collection)
+    {
+        $collection->removeAttributeToSelect();
+    }
+}

--- a/Model/Api/SearchCriteria/JoinProcessor/SkipCategoryIds.php
+++ b/Model/Api/SearchCriteria/JoinProcessor/SkipCategoryIds.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Model\Api\SearchCriteria\JoinProcessor;
+
+use Magento\Eav\Model\Entity\Collection\AbstractCollection;
+use Magento\Framework\Api\SearchCriteria\CollectionProcessor\JoinProcessor\CustomJoinInterface;
+use Magento\Framework\Data\Collection\AbstractDb;
+
+/**
+ * Skip loading category_ids attribute to product collection
+ */
+class SkipCategoryIds implements CustomJoinInterface
+{
+    /**
+     * @inheritDoc
+     * @param AbstractCollection $collection
+     */
+    public function apply(AbstractDb $collection)
+    {
+        $collection->setFlag('category_ids_added', true);
+    }
+}

--- a/Model/Indexing/Entity/Product/Scheduler/ItemsDataProvider.php
+++ b/Model/Indexing/Entity/Product/Scheduler/ItemsDataProvider.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Model\Indexing\Entity\Product\Scheduler;
+
+class ItemsDataProvider extends \HawkSearch\EsIndexing\Model\Indexing\Entity\Product\ItemsDataProvider
+{
+    public function getItems($storeId, $entityIds = null, $currentPage = 1, $pageSize = 0)
+    {
+        return $this->getProductCollection($storeId, $entityIds, $currentPage, $pageSize);
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1303,10 +1303,45 @@
         </arguments>
     </virtualType>
 
+    <virtualType name="HawkSearch\EsIndexing\Model\Indexing\EntityType\Scheduler\ProductEntityType"
+                 type="HawkSearch\EsIndexing\Model\Indexing\EntityType\ProductEntityType">
+        <arguments>
+            <argument name="itemsDataProvider" xsi:type="object">HawkSearch\EsIndexing\Model\Indexing\Entity\Product\Scheduler\ItemsDataProvider</argument>
+        </arguments>
+    </virtualType>
+    <type name="HawkSearch\EsIndexing\Model\Indexing\Entity\Product\Scheduler\ItemsDataProvider">
+        <arguments>
+            <argument name="productRepository" xsi:type="object">HawkSearch\EsIndexing\Model\Indexing\Entity\Product\Scheduler\ProductRepository</argument>
+        </arguments>
+    </type>
+    <virtualType name="HawkSearch\EsIndexing\Model\Indexing\Entity\Product\Scheduler\ProductRepository" type="Magento\Catalog\Model\ProductRepository">
+        <arguments>
+            <argument name="collectionProcessor" xsi:type="object">HawkSearch\EsIndexing\Model\Api\SearchCriteria\Scheduler\ProductCollectionProcessor</argument>
+            <argument name="readExtensions" xsi:type="object">HawkSearch\EsIndexing\Product\EntityManager\Operation\Read\ReadExtensions</argument>
+            <argument name="collectionFactory" xsi:type="object">HawkSearch\EsIndexing\Model\ResourceModel\Product\CollectionFactory</argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="HawkSearch\EsIndexing\Model\Api\SearchCriteria\Scheduler\ProductCollectionProcessor"
+                 type="Magento\Catalog\Model\Api\SearchCriteria\ProductCollectionProcessor">
+        <arguments>
+            <argument name="processors" xsi:type="array">
+                <item name="joins" xsi:type="object">HawkSearch\EsIndexing\Model\Api\SearchCriteria\Scheduler\CollectionProcessor\ProductItemsJoinProcessor</item>
+            </argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="HawkSearch\EsIndexing\Model\Api\SearchCriteria\Scheduler\CollectionProcessor\ProductItemsJoinProcessor"
+                 type="HawkSearch\EsIndexing\Model\Api\SearchCriteria\CollectionProcessor\CustomJoinProcessor">
+        <arguments>
+            <argument name="customJoins" xsi:type="array">
+                <item name="clean_attributes" xsi:type="object">HawkSearch\EsIndexing\Model\Api\SearchCriteria\JoinProcessor\CleanAttributes</item>
+                <item name="skip_cetegory_ids" xsi:type="object">HawkSearch\EsIndexing\Model\Api\SearchCriteria\JoinProcessor\SkipCategoryIds</item>
+            </argument>
+        </arguments>
+    </virtualType>
     <virtualType name="HawkSearch\EsIndexing\Model\Indexer\Entities\Scheduler\Product"
                  type="HawkSearch\EsIndexing\Model\Indexer\Entities\SchedulerAbstract">
         <arguments>
-            <argument name="entityType" xsi:type="object">HawkSearch\EsIndexing\Model\Indexing\EntityType\ProductEntityType</argument>
+            <argument name="entityType" xsi:type="object">HawkSearch\EsIndexing\Model\Indexing\EntityType\Scheduler\ProductEntityType</argument>
         </arguments>
     </virtualType>
     <virtualType name="HawkSearch\EsIndexing\Model\Indexer\Entities\Scheduler\ContentPage"


### PR DESCRIPTION
Optimize product collection loading when bin/magento indexer:reindex command is executed. Avoid loading useless data because index scheduler just requires to know the collection size.

Ref: HC-1690