### PR TITLE
fix: getCurrentIndex error is displayed in CLI

### DIFF
--- a/Gateway/Validator/GetCurentIndexBadRequestValidator.php
+++ b/Gateway/Validator/GetCurentIndexBadRequestValidator.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2023 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ * Copyright (c) 2024 Hawksearch (www.hawksearch.com) - All Rights Reserved
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -17,9 +17,9 @@ namespace HawkSearch\EsIndexing\Gateway\Validator;
 
 use HawkSearch\Connector\Gateway\Validator\ResultInterface;
 
-class GetIndexListBadRequestValidator extends BadRequestValidator
+class GetCurentIndexBadRequestValidator extends BadRequestValidator
 {
-    private const NO_INDECES_MESSAGE = "There are no indices.";
+    private const NO_INDEX_MESSAGE = "Unable to retrieve the current index name.";
 
     /**
      * @inheritDoc
@@ -30,7 +30,7 @@ class GetIndexListBadRequestValidator extends BadRequestValidator
 
         if (!$result->isValid()) {
             $message = current($result->getFailsDescription());
-            if ($message == self::NO_INDECES_MESSAGE) {
+            if ($message == self::NO_INDEX_MESSAGE) {
                 $result = $this->createResult(true);
             }
         }

--- a/Model/EsIndex.php
+++ b/Model/EsIndex.php
@@ -22,10 +22,11 @@ class EsIndex extends AbstractSimpleObject implements EsIndexInterface
 {
     /**
      * @inheritDoc
+     * @return string
      */
-    public function getIndexName(): ?string
+    public function getIndexName(): string
     {
-        return $this->_get(self::INDEX_NAME);
+        return (string)$this->_get(self::INDEX_NAME);
     }
 
     /**

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -210,7 +210,7 @@
         <arguments>
             <argument name="requestBuilder" xsi:type="object">HawkSearch\Connector\Gateway\Request\BuilderComposite</argument>
             <argument name="transferFactory" xsi:type="object">HawkSearchEsIndexingGetCurrentIndexTransferFactory</argument>
-            <argument name="validator" xsi:type="object">HawkSearchEsIndexingBadResponseValidator</argument>
+            <argument name="validator" xsi:type="object">HawkSearchEsIndexingGetCurrentIndexBadResponseValidator</argument>
             <argument name="resultFactory" xsi:type="object">HawkSearchEsIndexingGetCurrentIndexResultFactory</argument>
         </arguments>
     </virtualType>
@@ -225,6 +225,18 @@
                  type="HawkSearch\Connector\Gateway\Instruction\ResultInterfaceFactory">
         <arguments>
             <argument xsi:type="string" name="instanceName">HawkSearch\EsIndexing\Gateway\Instruction\Result\EsIndexResult</argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="HawkSearchEsIndexingGetCurrentIndexBadResponseValidator"
+                 type="HawkSearch\Connector\Gateway\Validator\ValidatorComposite">
+        <arguments>
+            <argument name="validators" xsi:type="array">
+                <item name="badRequestValidator" xsi:type="string">HawkSearch\EsIndexing\Gateway\Validator\GetCurentIndexBadRequestValidator</item>
+            </argument>
+            <argument name="chainBreakingValidators" xsi:type="array">
+                <item name="httpCodeValidator" xsi:type="string">httpCodeValidator</item>
+                <item name="badRequestValidator" xsi:type="string">badRequestValidator</item>
+            </argument>
         </arguments>
     </virtualType>
     <!-- END getCurrentIndex Instruction  -->


### PR DESCRIPTION
For new clients who has no current index yet the full reindexing is breaking with the error: "Unable to retrieve the current index name."


This started happening after an update of Indexing API with a breaking change: response code for the scenario when there is no current index has been changed from 200 to 400.

Ref: HC-1714