### PR TITLE
fix: image and thumbnail attributes not indexing

### DIFF
--- a/Model/Product/Attributes.php
+++ b/Model/Product/Attributes.php
@@ -108,8 +108,8 @@ class Attributes
     {
         return [
             'type_id' => 'type_id',
-            'thumbnail_url' => 'thumbnail_url',
-            'image_url' => 'image_url',
+            'thumbnail_url' => 'thumbnail',
+            'image_url' => 'image',
             'name' => 'name',
             'sku' => 'sku',
             'category' => '',


### PR DESCRIPTION
Product Image URL andthumbnail URL always are indexed as placeholders.

ref: HC-1716