### PR TITLE
feat: declare public API contracts

### DIFF
--- a/Api/Data/EsIndexInterface.php
+++ b/Api/Data/EsIndexInterface.php
@@ -15,6 +15,12 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Api\Data;
 
+/**
+ * EsIndex Interface for Indexing API
+ *
+ * @api v2
+ * @since 0.8.0
+ */
 interface EsIndexInterface
 {
     /**#@+

--- a/Api/Data/FacetBoostBuryInterface.php
+++ b/Api/Data/FacetBoostBuryInterface.php
@@ -14,16 +14,18 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Api\Data;
 
-use Magento\Framework\Api\ExtensibleDataInterface;
-
 /**
+ * FacetBoostBury Interface used in Facet
+ *
  * @api v11
- * @see https://developerdocs.hawksearch.com/docs/facet-object#facet-boost-bury
+ * @since 0.8.0
+ * @see https://developerdocs.hawksearch.com/reference/facet_post_value
+ * @see https://dev.hawksearch.net/swagger/ui/index#!/Facet/Facet_Post_value
  *
  * Since properties in HawkSearch API can be nullable the following argument types in setters
  * should be nullable as well: strings, arrays and objects
  */
-interface FacetBoostBuryInterface extends ExtensibleDataInterface
+interface FacetBoostBuryInterface
 {
     /**#@+
      * Constants for keys of data array

--- a/Api/Data/FacetInterface.php
+++ b/Api/Data/FacetInterface.php
@@ -15,9 +15,11 @@ declare(strict_types=1);
 namespace HawkSearch\EsIndexing\Api\Data;
 
 /**
+ * Facet Interface used in HawkSearch API
+ *
  * @api v11
- * @see https://developerdocs.hawksearch.com/reference/facet_get
- * @see https://developerdocs.hawksearch.com/docs/facet-object
+ * @see https://developerdocs.hawksearch.com/reference/facet_post_value
+ * @see https://dev.hawksearch.net/swagger/ui/index#!/Facet/Facet_Post_value
  *
  * Since properties in HawkSearch API can be nullable the following argument types in setters
  * should be nullable as well: strings, arrays and objects
@@ -27,8 +29,8 @@ interface FacetInterface
     /**#@+
      * Constants for keys of data array
      */
-    const FACET_ID = 'FacetId';
     const SYNC_GUID = 'SyncGuid';
+    const FACET_ID = 'FacetId';
     const NAME = 'Name';
     const FACET_TYPE = 'FacetType';
     const FIELD_TYPE = 'FieldType';
@@ -75,17 +77,6 @@ interface FacetInterface
     /**#@-*/
 
     /**
-     * @return int
-     */
-    public function getFacetId() : int;
-
-    /**
-     * @param int $value
-     * @return $this
-     */
-    public function setFacetId(int $value): FacetInterface;
-
-    /**
      * @return string
      */
     public function getSyncGuid() : string;
@@ -95,6 +86,17 @@ interface FacetInterface
      * @return $this
      */
     public function setSyncGuid(?string $value): FacetInterface;
+
+    /**
+     * @return int
+     */
+    public function getFacetId() : int;
+
+    /**
+     * @param int $value
+     * @return $this
+     */
+    public function setFacetId(int $value): FacetInterface;
 
     /**
      * @return string

--- a/Api/Data/FacetRangeModelInterface.php
+++ b/Api/Data/FacetRangeModelInterface.php
@@ -15,8 +15,12 @@ declare(strict_types=1);
 namespace HawkSearch\EsIndexing\Api\Data;
 
 /**
+ * FacetRangeModel Interface used in Facet
+ *
  * @api v11
- * @see https://developerdocs.hawksearch.com/docs/facet-object#facet-range
+ * @since 0.8.0
+ * @see https://developerdocs.hawksearch.com/reference/facet_post_value
+ * @see https://dev.hawksearch.net/swagger/ui/index#!/Facet/Facet_Post_value
  *
  * Since properties in HawkSearch API can be nullable the following argument types in setters
  * should be nullable as well: strings, arrays and objects

--- a/Api/Data/FacetValueOrderInfoInterface.php
+++ b/Api/Data/FacetValueOrderInfoInterface.php
@@ -15,8 +15,12 @@ declare(strict_types=1);
 namespace HawkSearch\EsIndexing\Api\Data;
 
 /**
+ * FacetValueOrderInfo Interface used in Facet
+ *
  * @api v11
- * @see https://developerdocs.hawksearch.com/docs/facet-object#facet-value-order-info
+ * @since 0.8.0
+ * @see https://developerdocs.hawksearch.com/reference/facet_post_value
+ * @see https://dev.hawksearch.net/swagger/ui/index#!/Facet/Facet_Post_value
  *
  * Since properties in HawkSearch API can be nullable the following argument types in setters
  * should be nullable as well: strings, arrays and objects

--- a/Api/Data/FieldInterface.php
+++ b/Api/Data/FieldInterface.php
@@ -16,8 +16,9 @@ namespace HawkSearch\EsIndexing\Api\Data;
 
 /**
  * @api v11
- * @see https://developerdocs.hawksearch.com/reference/field_get
- * @see https://developerdocs.hawksearch.com/docs/field-object
+ * @since 0.8.0
+ * @see https://developerdocs.hawksearch.com/reference/field_post_value
+ * @see https://dev.hawksearch.net/swagger/ui/index#!/Field/Field_Post_value
  *
  * Since properties in HawkSearch API can be nullable the following argument types in setters
  * should be nullable as well: strings, arrays and objects
@@ -29,13 +30,13 @@ interface FieldInterface
      */
     const FIELD_ID = 'FieldId';
     const SYNC_GUID = 'SyncGuid';
-    const NAME = 'Name';
-    const FIELD_TYPE = 'FieldType';
     const LABEL = 'Label';
+    const NAME = 'Name';
+    const IS_PRIMARY_KEY = 'IsPrimaryKey';
     const TYPE = 'Type';
+    const FIELD_TYPE = 'FieldType';
     const BOOST = 'Boost';
     const FACET_HANDLER = 'FacetHandler';
-    const IS_PRIMARY_KEY = 'IsPrimaryKey';
     const IS_OUTPUT = 'IsOutput';
     const IS_SHINGLE = 'IsShingle';
     const IS_BEST_FRAGMENT = 'IsBestFragment';
@@ -106,28 +107,6 @@ interface FieldInterface
     /**
      * @return string
      */
-    public function getName(): string;
-
-    /**
-     * @param string|null $value
-     * @return $this
-     */
-    public function setName(?string $value): FieldInterface;
-
-    /**
-     * @return string
-     */
-    public function getFieldType(): string;
-
-    /**
-     * @param string|null $value
-     * @return $this
-     */
-    public function setFieldType(?string $value): FieldInterface;
-
-    /**
-     * @return string
-     */
     public function getLabel(): string;
 
     /**
@@ -139,6 +118,28 @@ interface FieldInterface
     /**
      * @return string
      */
+    public function getName(): string;
+
+    /**
+     * @param string|null $value
+     * @return $this
+     */
+    public function setName(?string $value): FieldInterface;
+
+    /**
+     * @return bool
+     */
+    public function getIsPrimaryKey(): bool;
+
+    /**
+     * @param bool $value
+     * @return $this
+     */
+    public function setIsPrimaryKey(bool $value): FieldInterface;
+
+    /**
+     * @return string
+     */
     public function getType(): string;
 
     /**
@@ -146,6 +147,17 @@ interface FieldInterface
      * @return $this
      */
     public function setType(?string $value): FieldInterface;
+
+    /**
+     * @return string
+     */
+    public function getFieldType(): string;
+
+    /**
+     * @param string|null $value
+     * @return $this
+     */
+    public function setFieldType(?string $value): FieldInterface;
 
     /**
      * @return int
@@ -168,17 +180,6 @@ interface FieldInterface
      * @return $this
      */
     public function setFacetHandler(int $value): FieldInterface;
-
-    /**
-     * @return bool
-     */
-    public function getIsPrimaryKey(): bool;
-
-    /**
-     * @param bool $value
-     * @return $this
-     */
-    public function setIsPrimaryKey(bool $value): FieldInterface;
 
     /**
      * @return bool

--- a/Api/Data/HierarchyInterface.php
+++ b/Api/Data/HierarchyInterface.php
@@ -14,6 +14,16 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Api\Data;
 
+/**
+ * @api
+ * @since 0.8.0
+ * @see https://developerdocs.hawksearch.com/reference/hierarchy_upsert-1
+ * @see https://indexing-dev.hawksearch.net/swagger/ui/index#!/Hierarchy/Hierarchy_Upsert
+ * @todo interface is not used yet. Use it in Indexing API requests/responses
+ *
+ * Since properties in HawkSearch API can be nullable the following argument types in setters
+ * should be nullable as well: strings, arrays and objects
+ */
 interface HierarchyInterface
 {
     /**#@+

--- a/Api/Data/IndexItemInterface.php
+++ b/Api/Data/IndexItemInterface.php
@@ -15,6 +15,10 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Api\Data;
 
+/**
+ * @internal interface is not used yet
+ * @todo define interface methods
+ */
 interface IndexItemInterface
 {
 

--- a/Api/Data/IndexItemsContextInterface.php
+++ b/Api/Data/IndexItemsContextInterface.php
@@ -15,6 +15,12 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Api\Data;
 
+/**
+ * IndexItemsContext interface is used in index-items method of Indexing API
+ * @internal interface is not used yet
+ * @see https://developerdocs.hawksearch.com/reference/indexv2_index-1
+ * @see https://indexing-dev.hawksearch.net/swagger/ui/index#!/IndexV2/IndexV2_Index
+ */
 interface IndexItemsContextInterface
 {
     /**#@+

--- a/Api/Data/IndexListInterface.php
+++ b/Api/Data/IndexListInterface.php
@@ -15,6 +15,10 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Api\Data;
 
+/**
+ * @api v11
+ * @since 0.8.0
+ */
 interface IndexListInterface
 {
     /**#@+

--- a/Api/Data/LandingPageInterface.php
+++ b/Api/Data/LandingPageInterface.php
@@ -12,6 +12,14 @@
  */
 namespace HawkSearch\EsIndexing\Api\Data;
 
+/**
+ * LandingPage Interface used in HawkSearch API
+ *
+ * @api v11
+ * @since 0.8.0
+ * @link https://developerdocs.hawksearch.com/reference/landingpage_postvalue_value
+ * @link https://dev.hawksearch.net/swagger/ui/index#!/LandingPage/LandingPage_PostValue_value
+ */
 interface LandingPageInterface
 {
     /**#@+

--- a/Api/Data/QueueOperationDataInterface.php
+++ b/Api/Data/QueueOperationDataInterface.php
@@ -14,6 +14,12 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Api\Data;
 
+/**
+ * Interface for operations used in message topics processed by `hawksearch.indexing` consumer
+ *
+ * @api
+ * @since 0.8.0
+ */
 interface QueueOperationDataInterface
 {
     /**

--- a/Api/FacetManagementInterface.php
+++ b/Api/FacetManagementInterface.php
@@ -17,6 +17,12 @@ namespace HawkSearch\EsIndexing\Api;
 use HawkSearch\EsIndexing\Api\Data\FacetInterface;
 use Magento\Framework\Exception\CouldNotSaveException;
 
+/**
+ * Interface for managing Facets in HawkSearch
+ *
+ * @api
+ * @since 0.8.0
+ */
 interface FacetManagementInterface
 {
     /**

--- a/Api/FieldManagementInterface.php
+++ b/Api/FieldManagementInterface.php
@@ -17,6 +17,12 @@ namespace HawkSearch\EsIndexing\Api;
 use HawkSearch\EsIndexing\Api\Data\FieldInterface;
 use Magento\Framework\Exception\CouldNotSaveException;
 
+/**
+ * Interface for managing Fields in HawkSearch
+ *
+ * @api
+ * @since 0.8.0
+ */
 interface FieldManagementInterface
 {
     /**

--- a/Api/HierarchyManagementInterface.php
+++ b/Api/HierarchyManagementInterface.php
@@ -14,10 +14,16 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Api;
 
+/**
+ * Interface for managing Hierarchy in HawkSearch
+ *
+ * @api
+ * @since 0.8.0
+ */
 interface HierarchyManagementInterface
 {
     /**
-     * Upseart Hierarchy
+     * Upsert Hierarchy
      * @param array $items
      * @param string $indexName
      * @return void

--- a/Api/IndexManagementInterface.php
+++ b/Api/IndexManagementInterface.php
@@ -17,12 +17,18 @@ namespace HawkSearch\EsIndexing\Api;
 
 use HawkSearch\EsIndexing\Api\Data\EsIndexInterface;
 
+/**
+ * Interface for managing Indexes and items in HawkSearch indices.
+ *
+ * @api
+ * @since 0.8.0
+ */
 interface IndexManagementInterface
 {
     /**
      * Start process of full reindexing
      * We consider that number of indices per engine is equal to 2
-     * Non current index is the only index which can be processed during full reindexing
+     * Non-current index is the only index which can be processed during full reindexing
      * @return void
      */
     public function initializeFullReindex();
@@ -57,6 +63,7 @@ interface IndexManagementInterface
      * @param array $items
      * @param string $indexName
      * @return void
+     * @todo use \HawkSearch\EsIndexing\Api\Data\IndexItemsContextInterface as input array
      */
     public function indexItems(array $items, string $indexName);
 

--- a/Api/LandingPageManagementInterface.php
+++ b/Api/LandingPageManagementInterface.php
@@ -14,6 +14,12 @@ namespace HawkSearch\EsIndexing\Api;
 
 use HawkSearch\EsIndexing\Api\Data\LandingPageInterface;
 
+/**
+ * Interface for managing Landing Pages in HawkSearch
+ *
+ * @api
+ * @since 0.8.0
+ */
 interface LandingPageManagementInterface
 {
     /**

--- a/Block/Adminhtml/Bulk/Details/BackButton.php
+++ b/Block/Adminhtml/Bulk/Details/BackButton.php
@@ -16,7 +16,8 @@ use HawkSearch\EsIndexing\Block\Adminhtml\Form\GenericButton;
 use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
 
 /**
- * Class BackButton
+ * @api
+ * @since 0.8.0
  */
 class BackButton extends GenericButton implements ButtonProviderInterface
 {

--- a/Block/Adminhtml/Bulk/Details/RetryButton.php
+++ b/Block/Adminhtml/Bulk/Details/RetryButton.php
@@ -18,10 +18,20 @@ use Magento\AsynchronousOperations\Model\Operation\Details;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 class RetryButton implements ButtonProviderInterface
 {
+    /**
+     * @var RequestInterface
+     */
     private RequestInterface $request;
 
+    /**
+     * @var Details
+     */
     private Details $details;
 
     /**

--- a/Block/Adminhtml/Form/GenericButton.php
+++ b/Block/Adminhtml/Form/GenericButton.php
@@ -16,6 +16,10 @@ namespace HawkSearch\EsIndexing\Block\Adminhtml\Form;
 
 use Magento\Backend\Block\Widget\Context;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 class GenericButton
 {
     /**

--- a/Block/Tracking.php
+++ b/Block/Tracking.php
@@ -24,22 +24,26 @@ use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Item;
 use Magento\Sales\Model\ResourceModel\Order\CollectionFactory as OrderCollectionFactory;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 class Tracking extends Template
 {
     /**
      * @var OrderCollectionFactory
      */
-    private $orderCollectionFactory;
+    private OrderCollectionFactory $orderCollectionFactory;
 
     /**
      * @var ProductEntityType
      */
-    private $productEntityType;
+    private ProductEntityType $productEntityType;
 
     /**
      * @var EventTrackingConfig
      */
-    private $eventTrackingConfig;
+    private EventTrackingConfig $eventTrackingConfig;
 
     /**
      * @param Template\Context $context

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,94 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 See tasks currently in development on [Unreleased] changes page.
 
+## [Unreleased]
+
+### API CHANGES
+#### Interfaces
+The following interfaces in `\HawkSearch\EsIndexing` namespace are defined as `@api`:
+- Api\Data\BoostQueryInterface
+- Api\Data\ClientDataInterface
+- Api\Data\CoordinateInterface
+- Api\Data\EsIndexInterface
+- Api\Data\FacetBoostBuryInterface
+- Api\Data\FacetInterface
+- Api\Data\FacetRangeModelInterface
+- Api\Data\FacetValueOrderInfoInterface
+- Api\Data\FieldInterface
+- Api\Data\HierarchyInterface
+- Api\Data\IndexListInterface
+- Api\Data\LandingPageInterface
+- Api\Data\QueueOperationDataInterface
+- Api\Data\SearchRequestInterface
+- Api\Data\SmartBarInterface
+- Api\Data\VariantOptionsInterface
+- Api\FacetManagementInterface
+- Api\FieldManagementInterface
+- Api\HierarchyManagementInterface
+- Api\IndexManagementInterface
+- Api\LandingPageManagementInterface
+- Model\Indexer\Entities\SchedulerInterface
+- Model\Indexing\ContextInterface
+- Model\Indexing\FieldHandlerInterface
+- Model\Indexing\EntityRebuildInterface
+- Model\Indexing\EntityTypeInterface
+- Model\Indexing\Field\NameProviderInterface
+- Model\Indexing\ItemsDataProviderInterface
+- Model\Indexing\ItemsIndexerInterface
+- Model\Layout\LayoutConfigProcessorInterface
+- Model\MessageQueue\Validator\OperationValidatorInterface
+- Model\MessageQueue\BulkPublisherInterface
+- Model\MessageQueue\MessageManagerInterface
+- Model\MessageQueue\MessageTopicResolverInterface
+- Model\Product\Attribute\ExcludeNotVisibleProductsFlagInterface
+- Model\Product\PriceManagementInterface
+- Model\Product\ProductTypeInterface
+- Model\Product\ProductTypePoolInterface
+- Service\DataStorageInterface
+- 
+
+The following interfaces in `\HawkSearch\EsIndexing` namespace are defined as `@internal` (including experimental features):
+- Api\Data\IndexItemInterface
+- Api\Data\IndexItemsContextInterface
+- Model\Config\Backend\Serialized\Processor\ValueProcessorInterface
+- Model\Field\FieldExtendedInterface
+
+#### Classes
+The following classes in `\HawkSearch\EsIndexing` namespace are defined as `@api`:
+- Block\Adminhtml\Bulk\Details\BackButton
+- Block\Adminhtml\Bulk\Details\RetryButton
+- Block\Adminhtml\Form\GenericButton
+- Block\Tracking
+- Registry\CurrentCategory
+- Service\DataStorage
+- Model\BulkOperation\BulkOperationManagement
+- Model\Indexer\Entities\ActionAbstract
+- Model\Indexer\Entities\SchedulerAbstract
+- Model\Indexer\Entities\SchedulerComposite
+- Model\Indexing\AbstractConfigHelper
+- Model\Indexing\AbstractEntityRebuild
+- Model\Indexing\Field\DefaultNameProvider
+- Model\Indexing\FieldHandler\Composite
+- Model\Indexing\FieldHandler\DataObjectHandler
+- Model\Layout\CompositeConfigProcessor
+- Model\MessageQueue\Consumer
+- Model\MessageQueue\Exception\InvalidBulkOperationException
+- Model\MessageQueue\MessageTopicByObjectResolver
+- Model\MessageQueue\QueueOperationData
+- Model\FacetManagement
+- Model\FieldManagement
+- Model\HierarchyManagement
+- Model\IndexManagement
+- Model\LandingPageManagement
+- Model\Product
+- Model\Product\Attributes
+- Model\Product\PriceManagement
+- Model\Product\ProductType\CompositeType
+- Model\Product\ProductType\DefaultType
+- Model\Product\ProductTypePool
+
+
+
 ## [0.7.4] - 2024-11-19
 ### FIXES
 * **fix: image and thumbnail attributes not indexing** ([#81](https://github.com/hawksearch/esindexing-magento-2/pull/81))

--- a/Helper/ObjectHelper.php
+++ b/Helper/ObjectHelper.php
@@ -22,6 +22,10 @@ use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\Api\SimpleDataObjectConverter;
 use Magento\Framework\Api\SortOrderFactory;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 class ObjectHelper
 {
     /**

--- a/Helper/PricingHelper.php
+++ b/Helper/PricingHelper.php
@@ -22,6 +22,10 @@ use Magento\Store\Model\Store;
 use Magento\Tax\Helper\Data as TaxHelper;
 use Magento\Tax\Model\Config as TaxConfig;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 class PricingHelper extends AbstractHelper
 {
     /**

--- a/Model/BulkOperation/BulkOperationManagement.php
+++ b/Model/BulkOperation/BulkOperationManagement.php
@@ -25,6 +25,10 @@ use Magento\Framework\Api\SearchCriteriaBuilderFactory;
 use Magento\Framework\Bulk\OperationInterface as BulkOperationInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 class BulkOperationManagement
 {
     public const OPERATION_TOPIC_PREFIX = 'hawksearch.indexing.';

--- a/Model/Config/Backend/Serialized/Processor/ValueProcessorInterface.php
+++ b/Model/Config/Backend/Serialized/Processor/ValueProcessorInterface.php
@@ -16,6 +16,9 @@ namespace HawkSearch\EsIndexing\Model\Config\Backend\Serialized\Processor;
 
 use Magento\Framework\App\Config\ValueInterface;
 
+/**
+ * @internal
+ */
 interface ValueProcessorInterface
 {
     /**#@+

--- a/Model/Facet.php
+++ b/Model/Facet.php
@@ -64,22 +64,6 @@ class Facet extends AbstractSimpleObject implements FacetInterface
     /**
      * @inheritDoc
      */
-    public function getFacetId(): int
-    {
-        return (int)$this->_get(self::FACET_ID);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function setFacetId(int $value): FacetInterface
-    {
-        return $this->setData(self::FACET_ID, $value);
-    }
-
-    /**
-     * @inheritDoc
-     */
     public function getSyncGuid(): string
     {
         return (string)$this->_get(self::SYNC_GUID);
@@ -91,6 +75,22 @@ class Facet extends AbstractSimpleObject implements FacetInterface
     public function setSyncGuid(?string $value): FacetInterface
     {
         return $this->setData(self::SYNC_GUID, $value);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getFacetId(): int
+    {
+        return (int)$this->_get(self::FACET_ID);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setFacetId(int $value): FacetInterface
+    {
+        return $this->setData(self::FACET_ID, $value);
     }
 
     /**

--- a/Model/FacetManagement.php
+++ b/Model/FacetManagement.php
@@ -19,6 +19,10 @@ use HawkSearch\EsIndexing\Api\Data\FacetInterface;
 use HawkSearch\EsIndexing\Api\FacetManagementInterface;
 use Magento\Framework\Exception\CouldNotSaveException;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 class FacetManagement implements FacetManagementInterface
 {
     /**

--- a/Model/Field/FieldExtendedInterface.php
+++ b/Model/Field/FieldExtendedInterface.php
@@ -16,6 +16,10 @@ namespace HawkSearch\EsIndexing\Model\Field;
 
 use HawkSearch\EsIndexing\Api\Data\FieldInterface;
 
+
+/**
+ * @internal experimental feature
+ */
 interface FieldExtendedInterface
 {
     /**

--- a/Model/FieldManagement.php
+++ b/Model/FieldManagement.php
@@ -20,6 +20,10 @@ use HawkSearch\EsIndexing\Api\Data\FieldInterface;
 use HawkSearch\EsIndexing\Api\FieldManagementInterface;
 use Magento\Framework\Exception\CouldNotSaveException;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 class FieldManagement implements FieldManagementInterface
 {
     /**

--- a/Model/HierarchyManagement.php
+++ b/Model/HierarchyManagement.php
@@ -19,6 +19,10 @@ use HawkSearch\Connector\Gateway\InstructionException;
 use HawkSearch\EsIndexing\Api\HierarchyManagementInterface;
 use Magento\Framework\Exception\NotFoundException;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 class HierarchyManagement implements HierarchyManagementInterface
 {
     /**

--- a/Model/IndexManagement.php
+++ b/Model/IndexManagement.php
@@ -26,6 +26,10 @@ use Magento\Framework\Exception\NotFoundException;
 use Magento\Store\Model\StoreManagerInterface;
 use Psr\Log\LoggerInterface;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 class IndexManagement implements IndexManagementInterface
 {
     /**

--- a/Model/Indexer/Entities/ActionAbstract.php
+++ b/Model/Indexer/Entities/ActionAbstract.php
@@ -19,6 +19,10 @@ use HawkSearch\EsIndexing\Model\MessageQueue\MessageManagerInterface;
 use Magento\Framework\Event\ManagerInterface;
 use Magento\Store\Api\Data\StoreInterface;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 abstract class ActionAbstract
 {
     /**

--- a/Model/Indexer/Entities/SchedulerAbstract.php
+++ b/Model/Indexer/Entities/SchedulerAbstract.php
@@ -22,6 +22,10 @@ use Magento\Framework\Event\ManagerInterface as EventManagerInterface;
 use Magento\Framework\Exception\InputException;
 use Magento\Store\Api\Data\StoreInterface;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 class SchedulerAbstract implements SchedulerInterface
 {
     /**

--- a/Model/Indexer/Entities/SchedulerComposite.php
+++ b/Model/Indexer/Entities/SchedulerComposite.php
@@ -18,6 +18,10 @@ use Magento\Framework\ObjectManager\TMap;
 use Magento\Framework\ObjectManager\TMapFactory;
 use Magento\Store\Api\Data\StoreInterface;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 class SchedulerComposite implements SchedulerInterface
 {
     /**

--- a/Model/Indexer/Entities/SchedulerInterface.php
+++ b/Model/Indexer/Entities/SchedulerInterface.php
@@ -16,6 +16,10 @@ namespace HawkSearch\EsIndexing\Model\Indexer\Entities;
 
 use Magento\Store\Api\Data\StoreInterface;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 interface SchedulerInterface
 {
     /**

--- a/Model/Indexing/AbstractConfigHelper.php
+++ b/Model/Indexing/AbstractConfigHelper.php
@@ -16,6 +16,10 @@ namespace HawkSearch\EsIndexing\Model\Indexing;
 
 use HawkSearch\EsIndexing\Model\Config\Indexing as IndexingConfig;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 abstract class AbstractConfigHelper
 {
     /**

--- a/Model/Indexing/AbstractEntityRebuild.php
+++ b/Model/Indexing/AbstractEntityRebuild.php
@@ -26,6 +26,10 @@ use Magento\Store\Model\StoreManagerInterface;
 use Psr\Log\LoggerInterface;
 use HawkSearch\EsIndexing\Model\Indexing\Field\NameProviderInterface as FieldNameProviderInterface;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 abstract class AbstractEntityRebuild implements EntityRebuildInterface
 {
     use PublicMethodDeprecationTrait;

--- a/Model/Indexing/ContextInterface.php
+++ b/Model/Indexing/ContextInterface.php
@@ -14,6 +14,10 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\Indexing;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 interface ContextInterface
 {
     /**

--- a/Model/Indexing/EntityRebuildInterface.php
+++ b/Model/Indexing/EntityRebuildInterface.php
@@ -17,6 +17,10 @@ namespace HawkSearch\EsIndexing\Model\Indexing;
 
 use Magento\Framework\Api\SearchCriteriaInterface;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 interface EntityRebuildInterface
 {
     /**

--- a/Model/Indexing/EntityTypeInterface.php
+++ b/Model/Indexing/EntityTypeInterface.php
@@ -18,9 +18,12 @@ namespace HawkSearch\EsIndexing\Model\Indexing;
 use HawkSearch\EsIndexing\Model\Indexing\Field\NameProviderInterface as FieldNameProviderInterface;
 
 /**
+ * @api
+ * @since 0.8.0
+ *
  * @method FieldHandlerInterface getFieldHandler() Use this method in your class implementations for smooth transitions
- *          since 0.9.0. Method will be added in 0.9.0
- * @method FieldNameProviderInterface getFieldNameProvider() Method will be added in 0.9.0
+ *          since 0.10.0. Method will be added in 0.10.0
+ * @method FieldNameProviderInterface getFieldNameProvider() Method will be added in 0.10.0
  */
 interface EntityTypeInterface
 {

--- a/Model/Indexing/Field/DefaultNameProvider.php
+++ b/Model/Indexing/Field/DefaultNameProvider.php
@@ -12,6 +12,10 @@
  */
 namespace HawkSearch\EsIndexing\Model\Indexing\Field;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 class DefaultNameProvider implements NameProviderInterface
 {
     /**

--- a/Model/Indexing/Field/NameProviderInterface.php
+++ b/Model/Indexing/Field/NameProviderInterface.php
@@ -14,6 +14,10 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\Indexing\Field;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 interface NameProviderInterface
 {
     /**

--- a/Model/Indexing/FieldHandler/Composite.php
+++ b/Model/Indexing/FieldHandler/Composite.php
@@ -18,6 +18,10 @@ use HawkSearch\EsIndexing\Model\Indexing\FieldHandlerInterface;
 use Magento\Framework\DataObject;
 use Magento\Framework\ObjectManagerInterface;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 class Composite implements FieldHandlerInterface
 {
     /**#@+

--- a/Model/Indexing/FieldHandler/DataObjectHandler.php
+++ b/Model/Indexing/FieldHandler/DataObjectHandler.php
@@ -17,6 +17,10 @@ namespace HawkSearch\EsIndexing\Model\Indexing\FieldHandler;
 use HawkSearch\EsIndexing\Model\Indexing\FieldHandlerInterface;
 use Magento\Framework\DataObject;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 class DataObjectHandler implements FieldHandlerInterface
 {
     /**

--- a/Model/Indexing/FieldHandlerInterface.php
+++ b/Model/Indexing/FieldHandlerInterface.php
@@ -16,6 +16,12 @@ namespace HawkSearch\EsIndexing\Model\Indexing;
 
 use Magento\Framework\DataObject;
 
+/**
+ * Handle value for HawkSearch field
+ *
+ * @api
+ * @since 0.8.0
+ */
 interface FieldHandlerInterface
 {
     /**

--- a/Model/Indexing/ItemsDataProviderInterface.php
+++ b/Model/Indexing/ItemsDataProviderInterface.php
@@ -15,6 +15,10 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\Indexing;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 interface ItemsDataProviderInterface
 {
     /**

--- a/Model/Indexing/ItemsIndexerInterface.php
+++ b/Model/Indexing/ItemsIndexerInterface.php
@@ -14,6 +14,10 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\Indexing;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 interface ItemsIndexerInterface
 {
     /**

--- a/Model/LandingPageManagement.php
+++ b/Model/LandingPageManagement.php
@@ -17,6 +17,10 @@ namespace HawkSearch\EsIndexing\Model;
 use HawkSearch\Connector\Gateway\Instruction\InstructionManagerPool;
 use HawkSearch\EsIndexing\Api\LandingPageManagementInterface;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 class LandingPageManagement implements LandingPageManagementInterface
 {
     /**

--- a/Model/Layout/CompositeConfigProcessor.php
+++ b/Model/Layout/CompositeConfigProcessor.php
@@ -14,6 +14,10 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\Layout;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 class CompositeConfigProcessor implements LayoutConfigProcessorInterface
 {
     /**

--- a/Model/Layout/LayoutConfigProcessorInterface.php
+++ b/Model/Layout/LayoutConfigProcessorInterface.php
@@ -14,6 +14,10 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\Layout;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 interface LayoutConfigProcessorInterface
 {
     /**

--- a/Model/MessageQueue/BulkPublisherInterface.php
+++ b/Model/MessageQueue/BulkPublisherInterface.php
@@ -14,6 +14,10 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\MessageQueue;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 interface BulkPublisherInterface
 {
     /**

--- a/Model/MessageQueue/Consumer.php
+++ b/Model/MessageQueue/Consumer.php
@@ -21,6 +21,10 @@ use Magento\Framework\Data\ObjectFactory;
 use Magento\Framework\DataObject;
 use Magento\Framework\Serialize\SerializerInterface;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 class Consumer
 {
     /**

--- a/Model/MessageQueue/Exception/InvalidBulkOperationException.php
+++ b/Model/MessageQueue/Exception/InvalidBulkOperationException.php
@@ -16,6 +16,10 @@ namespace HawkSearch\EsIndexing\Model\MessageQueue\Exception;
 
 use Magento\Framework\Exception\LocalizedException;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 class InvalidBulkOperationException extends LocalizedException
 {
 

--- a/Model/MessageQueue/MessageManagerInterface.php
+++ b/Model/MessageQueue/MessageManagerInterface.php
@@ -14,6 +14,10 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\MessageQueue;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 interface MessageManagerInterface
 {
     /**

--- a/Model/MessageQueue/MessageTopicByObjectResolver.php
+++ b/Model/MessageQueue/MessageTopicByObjectResolver.php
@@ -14,6 +14,10 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\MessageQueue;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 class MessageTopicByObjectResolver implements MessageTopicResolverInterface
 {
     /**

--- a/Model/MessageQueue/MessageTopicResolverInterface.php
+++ b/Model/MessageQueue/MessageTopicResolverInterface.php
@@ -16,6 +16,10 @@ namespace HawkSearch\EsIndexing\Model\MessageQueue;
 
 use Magento\Framework\Exception\InputException;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 interface MessageTopicResolverInterface
 {
     /**

--- a/Model/MessageQueue/QueueOperationData.php
+++ b/Model/MessageQueue/QueueOperationData.php
@@ -21,7 +21,7 @@ class QueueOperationData implements QueueOperationDataInterface
     /**
      * @var string
      */
-    private $data;
+    private string $data;
 
     /**
      * QueueOperationData constructor.
@@ -35,7 +35,7 @@ class QueueOperationData implements QueueOperationDataInterface
     /**
      * @inheritDoc
      */
-    public function getData()
+    public function getData(): string
     {
         return $this->data;
     }

--- a/Model/MessageQueue/Validator/OperationValidatorInterface.php
+++ b/Model/MessageQueue/Validator/OperationValidatorInterface.php
@@ -17,6 +17,10 @@ namespace HawkSearch\EsIndexing\Model\MessageQueue\Validator;
 use HawkSearch\EsIndexing\Model\MessageQueue\Exception\InvalidBulkOperationException;
 use Magento\Framework\Bulk\OperationInterface;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 interface OperationValidatorInterface
 {
     /**

--- a/Model/Product.php
+++ b/Model/Product.php
@@ -26,6 +26,10 @@ use Magento\Framework\App\ObjectManager;
 use Magento\Framework\EntityManager\EntityMetadataInterface;
 use Magento\Framework\EntityManager\MetadataPool;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 class Product
 {
     /**

--- a/Model/Product/Attribute/ExcludeNotVisibleProductsFlagInterface.php
+++ b/Model/Product/Attribute/ExcludeNotVisibleProductsFlagInterface.php
@@ -14,6 +14,10 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\Product\Attribute;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 interface ExcludeNotVisibleProductsFlagInterface
 {
     /**

--- a/Model/Product/Attributes.php
+++ b/Model/Product/Attributes.php
@@ -20,6 +20,10 @@ use Magento\Catalog\Model\Product;
 use Magento\Eav\Model\Config;
 use Magento\Framework\Serialize\Serializer\Json;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 class Attributes
 {
     /**

--- a/Model/Product/PriceManagement.php
+++ b/Model/Product/PriceManagement.php
@@ -17,8 +17,8 @@ namespace HawkSearch\EsIndexing\Model\Product;
 use Magento\Catalog\Api\Data\ProductInterface;
 
 /**
- * Class PriceManagement
- * @package HawkSearch\EsIndexing\Model\Product
+ * @api
+ * @since 0.8.0
  */
 class PriceManagement implements PriceManagementInterface
 {

--- a/Model/Product/PriceManagementInterface.php
+++ b/Model/Product/PriceManagementInterface.php
@@ -16,8 +16,8 @@ namespace HawkSearch\EsIndexing\Model\Product;
 use Magento\Catalog\Api\Data\ProductInterface;
 
 /**
- * Interface PriceManagementInterface
- * @package HawkSearch\EsIndexing\Model\Product
+ * @api
+ * @since 0.8.0
  */
 interface PriceManagementInterface
 {

--- a/Model/Product/ProductType/CompositeType.php
+++ b/Model/Product/ProductType/CompositeType.php
@@ -17,6 +17,10 @@ namespace HawkSearch\EsIndexing\Model\Product\ProductType;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\Product;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 abstract class CompositeType extends DefaultType
 {
     /**

--- a/Model/Product/ProductType/DefaultType.php
+++ b/Model/Product/ProductType/DefaultType.php
@@ -24,6 +24,10 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Module\Manager as ModuleManager;
 use Magento\Framework\Pricing\PriceCurrencyInterface;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 abstract class DefaultType implements ProductTypeInterface
 {
     /**

--- a/Model/Product/ProductTypeInterface.php
+++ b/Model/Product/ProductTypeInterface.php
@@ -16,8 +16,8 @@ use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\Product;
 
 /**
- * Interface ProductTypeInterface
- * @package HawkSearch\EsIndexing\Model\Product\Price
+ * @api
+ * @since 0.8.0
  */
 interface ProductTypeInterface
 {

--- a/Model/Product/ProductTypePool.php
+++ b/Model/Product/ProductTypePool.php
@@ -17,6 +17,10 @@ namespace HawkSearch\EsIndexing\Model\Product;
 use Magento\Framework\ObjectManager\TMap;
 use Magento\Framework\ObjectManager\TMapFactory;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 class ProductTypePool implements ProductTypePoolInterface
 {
     /**

--- a/Model/Product/ProductTypePoolInterface.php
+++ b/Model/Product/ProductTypePoolInterface.php
@@ -12,6 +12,10 @@
  */
 namespace HawkSearch\EsIndexing\Model\Product;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 interface ProductTypePoolInterface
 {
     /**

--- a/Registry/CurrentCategory.php
+++ b/Registry/CurrentCategory.php
@@ -17,6 +17,12 @@ namespace HawkSearch\EsIndexing\Registry;
 use Magento\Catalog\Api\Data\CategoryInterface;
 use Magento\Catalog\Api\Data\CategoryInterfaceFactory;
 
+/**
+ * Registry to access current active category on the page
+ *
+ * @api
+ * @since 0.8.0
+ */
 class CurrentCategory
 {
     /**

--- a/Service/DataStorage.php
+++ b/Service/DataStorage.php
@@ -16,12 +16,16 @@ namespace HawkSearch\EsIndexing\Service;
 
 use Magento\Framework\Exception\RuntimeException;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 class DataStorage implements DataStorageInterface
 {
     /**
      * @var string|null
      */
-    private $name;
+    private ?string $name;
 
     /**
      * @var mixed
@@ -94,7 +98,7 @@ class DataStorage implements DataStorageInterface
     }
 
     /**
-     * Destruct DataStorage value
+     * Reset DataStorage value
      */
     public function __destruct()
     {

--- a/Service/DataStorageInterface.php
+++ b/Service/DataStorageInterface.php
@@ -16,6 +16,10 @@ namespace HawkSearch\EsIndexing\Service;
 
 use Magento\Framework\Exception\RuntimeException;
 
+/**
+ * @api
+ * @since 0.8.0
+ */
 interface DataStorageInterface
 {
     /**


### PR DESCRIPTION
Define classes and interfaces related to public API using `@api` phpDoc attribute.
Define internal and experimental classes and interfaces with `@internal` phpDoc attribute.