### PR TITLE
feat: deprecate protected properties

### DIFF
--- a/Block/Adminhtml/System/Config/Product/CustomAttributes.php
+++ b/Block/Adminhtml/System/Config/Product/CustomAttributes.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Block\Adminhtml\System\Config\Product;
 
+use HawkSearch\Connector\Compatibility\PublicPropertyDeprecationTrait;
 use HawkSearch\EsIndexing\Block\Adminhtml\Form\Field\Select;
 use HawkSearch\EsIndexing\Model\Config\Backend\Serialized\Processor\ValueProcessorInterface;
 use HawkSearch\EsIndexing\Model\Config\Source\HawksearchFields;
@@ -26,10 +27,20 @@ use Magento\Framework\Exception\LocalizedException;
 
 class CustomAttributes extends AbstractFieldArray
 {
+    use PublicPropertyDeprecationTrait;
+
+    private array $deprecatedPublicProperties = [
+        'columnRendererCache' => [
+            'since' => '0.8.0',
+            'description' => 'Visibility changed to private.'
+        ]
+    ];
+
     /**
      * @var array
+     * @private 0.8.0 Visibility changed to private. Set via constructor injection.
      */
-    protected $columnRendererCache = [];
+    private array $columnRendererCache = [];
 
     /**
      * @var HawksearchFields
@@ -61,6 +72,7 @@ class CustomAttributes extends AbstractFieldArray
 
     /**
      * Prepare rendering the new field by adding all the needed columns
+     *
      * @throws LocalizedException
      */
     protected function _prepareToRender()
@@ -70,7 +82,7 @@ class CustomAttributes extends AbstractFieldArray
             [
                 'label' => __('Hawk Field Name'),
                 'class' => 'required-entry',
-                'options' => function() {
+                'options' => function () {
                     return $this->hawksearchFields->toOptionArray();
                 },
             ]
@@ -80,7 +92,7 @@ class CustomAttributes extends AbstractFieldArray
             ValueProcessorInterface::COLUMN_ATTRIBUTE,
             [
                 'label' => __('Product Attribute'),
-                'options' => function() {
+                'options' => function () {
                     return $this->productAttributes->toOptionArray();
                 },
             ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,20 @@ The following classes in `\HawkSearch\EsIndexing` namespace are defined as `@api
 - Model\Product\ProductType\DefaultType
 - Model\Product\ProductTypePool
 
+### DEPRECATIONS
 
+- Deprecate usage of protected property `Block\Adminhtml\System\Config\Product\CustomAttributes::columnRendererCache`. Visibility changed to private.
+- Deprecate usage of protected property `Model\Indexer\Entities\ActionAbstract::eventManager`. Visibility changed to private. Set via constructor injection.
+- Deprecate usage of protected property `Model\Indexer\Entities\ActionAbstract::messageManager`. Visibility changed to private. Set via constructor injection.
+- Deprecate usage of protected property `Model\Indexer\Entities\ActionAbstract::publisher`. Visibility changed to private. Set via constructor injection.
+- Deprecate usage of protected property `Model\Indexer\Entities\ActionAbstract::entityScheduler`. Visibility changed to private. Set via constructor injection.
+- Deprecate usage of protected property `Model\Indexer\Entities\SchedulerComposite::schedulers`. Visibility changed to private. Set via constructor injection.
+- Deprecate usage of protected property `Model\Indexing\AbstractEntityRebuild::entityTypePool`. Visibility changed to private. Set via constructor injection.
+- Deprecate usage of protected property `Model\Indexing\AbstractEntityRebuild::eventManager`. Visibility changed to private. Set via constructor injection.
+- Deprecate usage of protected property `Model\Indexing\AbstractEntityRebuild::hawkLogger`. Visibility changed to private. Set via `$loggerFactory` constructor injection.
+- Deprecate usage of protected property `Model\Indexing\AbstractEntityRebuild::storeManager`. Visibility changed to private. Set via constructor injection.
+- Deprecate usage of protected property `Model\Indexing\AbstractEntityRebuild::indexingContext`. Visibility changed to private. Set via constructor injection.
+- Deprecate usage of protected property `Model\Indexing\FieldHandler\Composite::handlers`. Visibility changed to private. Set via constructor injection.
 
 ## [0.7.4] - 2024-11-19
 ### FIXES

--- a/Model/Indexer/Entities/ActionAbstract.php
+++ b/Model/Indexer/Entities/ActionAbstract.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\Indexer\Entities;
 
+use HawkSearch\Connector\Compatibility\PublicPropertyDeprecationTrait;
 use HawkSearch\EsIndexing\Model\MessageQueue\BulkPublisherInterface;
 use HawkSearch\EsIndexing\Model\MessageQueue\MessageManagerInterface;
 use Magento\Framework\Event\ManagerInterface;
@@ -25,32 +26,58 @@ use Magento\Store\Api\Data\StoreInterface;
  */
 abstract class ActionAbstract
 {
+    use PublicPropertyDeprecationTrait;
+
+    private array $deprecatedPublicProperties = [
+        'eventManager' => [
+            'since' => '0.8.0',
+            'description' => 'Visibility changed to private. Set via constructor injection.'
+        ],
+        'messageManager' => [
+            'since' => '0.8.0',
+            'description' => 'Visibility changed to private. Set via constructor injection.'
+        ],
+        'publisher' => [
+            'since' => '0.8.0',
+            'description' => 'Visibility changed to private. Set via constructor injection.'
+        ],
+        'entityScheduler' => [
+            'since' => '0.8.0',
+            'description' => 'Visibility changed to private. Set via constructor injection.'
+        ],
+    ];
+
     /**
      * @var ManagerInterface
+     * @private 0.8.0 Visibility changed to private. Set via constructor injection.
      */
-    protected $eventManager;
+    private ManagerInterface $eventManager;
 
     /**
      * @var MessageManagerInterface
+     * @private 0.8.0 Visibility changed to private. Set via constructor injection.
      */
-    protected $messageManager;
+    private MessageManagerInterface $messageManager;
 
     /**
      * @var BulkPublisherInterface
+     * @private 0.8.0 Visibility changed to private. Set via constructor injection.
      */
-    protected $publisher;
+    private BulkPublisherInterface $publisher;
 
     /**
      * @var SchedulerInterface
+     * @private 0.8.0 Visibility changed to private. Set via constructor injection.
      */
-    protected $entityScheduler;
+    private SchedulerInterface $entityScheduler;
 
     public function __construct(
         ManagerInterface $eventManager,
         MessageManagerInterface $messageManager,
         BulkPublisherInterface $publisher,
         SchedulerInterface $entityScheduler
-    ) {
+    )
+    {
         $this->eventManager = $eventManager;
         $this->messageManager = $messageManager;
         $this->publisher = $publisher;

--- a/Model/Indexer/Entities/SchedulerComposite.php
+++ b/Model/Indexer/Entities/SchedulerComposite.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\Indexer\Entities;
 
+use HawkSearch\Connector\Compatibility\PublicPropertyDeprecationTrait;
 use Magento\Framework\ObjectManager\TMap;
 use Magento\Framework\ObjectManager\TMapFactory;
 use Magento\Store\Api\Data\StoreInterface;
@@ -27,10 +28,20 @@ use Magento\Store\Api\Data\StoreInterface;
  */
 class SchedulerComposite implements SchedulerInterface
 {
+    use PublicPropertyDeprecationTrait;
+
+    private array $deprecatedPublicProperties = [
+        'schedulers' => [
+            'since' => '0.8.0',
+            'description' => 'Visibility changed to private. Set via constructor injection.'
+        ],
+    ];
+
     /**
      * @var TMap<TKey, TValue>
+     * @private 0.8.0 Visibility changed to private. Set via constructor injection.
      */
-    protected $schedulers;
+    private TMap $schedulers;
 
     /**
      * @param TMapFactory $tmapFactory
@@ -39,7 +50,8 @@ class SchedulerComposite implements SchedulerInterface
     public function __construct(
         TMapFactory $tmapFactory,
         array $schedulers = []
-    ) {
+    )
+    {
         $this->schedulers = $tmapFactory->create(
             [
                 'array' => $schedulers,

--- a/Model/Indexing/AbstractEntityRebuild.php
+++ b/Model/Indexing/AbstractEntityRebuild.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace HawkSearch\EsIndexing\Model\Indexing;
 
 use HawkSearch\Connector\Compatibility\PublicMethodDeprecationTrait;
+use HawkSearch\Connector\Compatibility\PublicPropertyDeprecationTrait;
 use HawkSearch\Connector\Logger\LoggerFactoryInterface;
 use HawkSearch\EsIndexing\Helper\ObjectHelper;
 use HawkSearch\EsIndexing\Model\Indexing\Field\NameProviderInterface as FieldNameProviderInterface;
@@ -35,8 +36,9 @@ use Psr\Log\LoggerInterface;
 abstract class AbstractEntityRebuild implements EntityRebuildInterface
 {
     use PublicMethodDeprecationTrait;
+    use PublicPropertyDeprecationTrait;
 
-    private $deprecatedMethods = [
+    private array $deprecatedMethods = [
         'getAttributeValue' => [
             'since' => '0.7.0',
             'replacement' => __CLASS__ . '::getFieldValue()',
@@ -47,6 +49,29 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
             'replacement' => FieldNameProviderInterface::class,
             'description' => "The method will be removed. Using of 'code' and 'value' options is deprecated. Use " . FieldHandlerInterface::class . " to migrate fields with values."
         ]
+    ];
+
+    private array $deprecatedPublicProperties = [
+        'entityTypePool' => [
+            'since' => '0.8.0',
+            'description' => 'Visibility changed to private. Set via constructor injection.'
+        ],
+        'eventManager' => [
+            'since' => '0.8.0',
+            'description' => 'Visibility changed to private. Set via constructor injection.'
+        ],
+        'hawkLogger' => [
+            'since' => '0.8.0',
+            'description' => 'Visibility changed to private. Set via $loggerFactory constructor injection.'
+        ],
+        'storeManager' => [
+            'since' => '0.8.0',
+            'description' => 'Visibility changed to private. Set via constructor injection.'
+        ],
+        'indexingContext' => [
+            'since' => '0.8.0',
+            'description' => 'Visibility changed to private. Set via constructor injection.'
+        ],
     ];
 
     /**
@@ -66,28 +91,33 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
 
     /**
      * @var EntityTypePoolInterface<string, EntityTypeInterface>
+     * @deprecated 0.8.0 Visibility changed to private. Set via constructor injection.
      */
-    protected $entityTypePool;
+    private EntityTypePoolInterface $entityTypePool;
 
     /**
      * @var EventManagerInterface
+     * @deprecated 0.8.0 Visibility changed to private. Set via constructor injection.
      */
-    protected $eventManager;
+    private EventManagerInterface $eventManager;
 
     /**
      * @var LoggerInterface
+     * @deprecated 0.8.0 Visibility changed to private. Set via constructor injection.
      */
-    protected $hawkLogger;
+    private LoggerInterface $hawkLogger;
 
     /**
      * @var StoreManagerInterface
+     * @deprecated 0.8.0 Visibility changed to private. Set via constructor injection.
      */
-    protected $storeManager;
+    private StoreManagerInterface $storeManager;
 
     /**
      * @var ContextInterface
+     * @deprecated 0.8.0 Visibility changed to private. Set via constructor injection.
      */
-    protected $indexingContext;
+    private ContextInterface $indexingContext;
 
     /**
      * @var ObjectHelper

--- a/Model/Indexing/FieldHandler/Composite.php
+++ b/Model/Indexing/FieldHandler/Composite.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\Indexing\FieldHandler;
 
+use HawkSearch\Connector\Compatibility\PublicPropertyDeprecationTrait;
 use HawkSearch\EsIndexing\Model\Indexing\FieldHandlerInterface;
 use Magento\Framework\DataObject;
 use Magento\Framework\ObjectManagerInterface;
@@ -30,6 +31,15 @@ use Magento\Framework\ObjectManagerInterface;
  */
 class Composite implements FieldHandlerInterface
 {
+    use PublicPropertyDeprecationTrait;
+
+    private array $deprecatedPublicProperties = [
+        'handlers' => [
+            'since' => '0.8.0',
+            'description' => 'Visibility changed to private. Set via constructor injection.'
+        ],
+    ];
+
     /**#@+
      * Constants
      */
@@ -43,8 +53,9 @@ class Composite implements FieldHandlerInterface
 
     /**
      * @var HandlersMap
+     * @private 0.8.0 Visibility changed to private. Set via constructor injection.
      */
-    protected $handlers = [
+    private array $handlers = [
         self::HANDLER_DEFAULT_NAME => DataObjectHandler::class
     ];
 

--- a/Model/Product/ProductType/Bundle.php
+++ b/Model/Product/ProductType/Bundle.php
@@ -14,16 +14,26 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\Product\ProductType;
 
+use HawkSearch\Connector\Compatibility\PublicPropertyDeprecationTrait;
 use Magento\Bundle\Model\Product\Price;
 use Magento\Catalog\Api\Data\ProductInterface;
 
 class Bundle extends CompositeType
 {
+    use PublicPropertyDeprecationTrait;
+
+    private array $deprecatedPublicProperties = [
+        'keySelectionsCollection' => [
+            'since' => '0.7.0',
+            'description' => 'Property will be removed.'
+        ],
+    ];
+
     /**
      * @var string
      * @deprecated since 0.7.0 will be removed
      */
-    protected string $keySelectionsCollection = '_cache_instance_selections_collection_hawksearch';
+    private string $keySelectionsCollection = '_cache_instance_selections_collection_hawksearch';
 
     /**
      * @inheritDoc

--- a/Test/Unit/Block/Adminhtml/System/Config/Product/CustomAttributesTest.php
+++ b/Test/Unit/Block/Adminhtml/System/Config/Product/CustomAttributesTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Copyright (c) 2025 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Test\Unit\Block\Adminhtml\System\Config\Product;
+
+use HawkSearch\Connector\Test\Unit\Compatibility\Fixtures\AccessClassPropertyFixtureTrait;
+use HawkSearch\Connector\Test\Unit\Compatibility\LegacyBaseTrait;
+use HawkSearch\EsIndexing\Block\Adminhtml\System\Config\Product\CustomAttributes;
+use HawkSearch\EsIndexing\Model\Config\Source\HawksearchFields;
+use HawkSearch\EsIndexing\Model\Config\Source\ProductAttributes;
+use Magento\Backend\Block\Template\Context;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class CustomAttributesTest extends TestCase
+{
+    use LegacyBaseTrait;
+
+    private Context|MockObject $contextMock;
+    private MockObject|HawksearchFields $hawksearchFieldsMock;
+    private MockObject|ProductAttributes $productAttributesMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpLegacy($this);
+
+        $this->contextMock = $this->getMockBuilder(Context::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->hawksearchFieldsMock = $this->getMockBuilder(HawksearchFields::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->productAttributesMock = $this->getMockBuilder(ProductAttributes::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownLegacy($this);
+        parent::tearDown();
+    }
+
+    /**
+     * @requires PHP <8.2.0
+     * @group legacy
+     */
+    #[RequiresPhp('<8.2.0')]
+    public function testAccessingDeprecatedPropertiesPhp81(): void
+    {
+        $model = new TestFixtureSubCustomAttributesLegacy(
+            $this->contextMock,
+            $this->hawksearchFieldsMock,
+            $this->productAttributesMock,
+            []
+        );
+
+        $this->assertLegacyProperty('columnRendererCache', ['test_renderer' => []], $model, $this, [
+            "Since 0.8.0: Property HawkSearch\EsIndexing\Block\Adminhtml\System\Config\Product\CustomAttributes::columnRendererCache has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private.",
+            "Since 0.8.0: Property HawkSearch\EsIndexing\Block\Adminhtml\System\Config\Product\CustomAttributes::columnRendererCache has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private.",
+            "Since 0.8.0: Property HawkSearch\EsIndexing\Block\Adminhtml\System\Config\Product\CustomAttributes::columnRendererCache has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private.",
+            "Since 0.8.0: Property HawkSearch\EsIndexing\Block\Adminhtml\System\Config\Product\CustomAttributes::columnRendererCache has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private.",
+            "Since 0.8.0: Property HawkSearch\EsIndexing\Block\Adminhtml\System\Config\Product\CustomAttributes::columnRendererCache has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private.",
+            "Since 0.8.0: Property HawkSearch\EsIndexing\Block\Adminhtml\System\Config\Product\CustomAttributes::columnRendererCache has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private.",
+        ]);
+    }
+
+    /**
+     * @requires PHP >=8.2.0
+     * @group legacy
+     */
+    #[RequiresPhp('>=8.2.0')]
+    public function testAccessingDeprecatedPropertiesPhp82(): void
+    {
+        $model = new TestFixtureSubCustomAttributesLegacy(
+            $this->contextMock,
+            $this->hawksearchFieldsMock,
+            $this->productAttributesMock,
+            []
+        );
+
+        $this->assertLegacyProperty('columnRendererCache', ['test_renderer' => []], $model, $this, [
+            "Since 0.8.0: Property HawkSearch\EsIndexing\Block\Adminhtml\System\Config\Product\CustomAttributes::columnRendererCache has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private.",
+            "Since 0.8.0: Property HawkSearch\EsIndexing\Block\Adminhtml\System\Config\Product\CustomAttributes::columnRendererCache has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private.",
+            "Creation of dynamic property via __set(): HawkSearch\EsIndexing\Test\Unit\Block\Adminhtml\System\Config\Product\TestFixtureSubCustomAttributesLegacy::\$columnRendererCache is deprecated",
+            "Since 0.8.0: Property HawkSearch\EsIndexing\Block\Adminhtml\System\Config\Product\CustomAttributes::columnRendererCache has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private.",
+            "Since 0.8.0: Property HawkSearch\EsIndexing\Block\Adminhtml\System\Config\Product\CustomAttributes::columnRendererCache has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private.",
+            "Since 0.8.0: Property HawkSearch\EsIndexing\Block\Adminhtml\System\Config\Product\CustomAttributes::columnRendererCache has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private.",
+            "Since 0.8.0: Property HawkSearch\EsIndexing\Block\Adminhtml\System\Config\Product\CustomAttributes::columnRendererCache has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private.",
+        ]);
+    }
+}
+
+/**
+ * @group legacy
+ */
+class TestFixtureSubCustomAttributesLegacy extends CustomAttributes
+{
+    use AccessClassPropertyFixtureTrait;
+}

--- a/Test/Unit/Model/Indexer/Entities/ActionAbstractTest.php
+++ b/Test/Unit/Model/Indexer/Entities/ActionAbstractTest.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * Copyright (c) 2025 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Test\Unit\Model\Indexer\Entities;
+
+use HawkSearch\Connector\Test\Unit\Compatibility\Fixtures\AccessClassPropertyFixtureTrait;
+use HawkSearch\Connector\Test\Unit\Compatibility\LegacyBaseTrait;
+use HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract;
+use HawkSearch\EsIndexing\Model\Indexer\Entities\SchedulerInterface;
+use HawkSearch\EsIndexing\Model\MessageQueue\BulkPublisherInterface;
+use HawkSearch\EsIndexing\Model\MessageQueue\MessageManagerInterface;
+use Magento\Framework\Event\ManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ActionAbstractTest extends TestCase
+{
+    use LegacyBaseTrait;
+
+    private ManagerInterface|MockObject $eventManagerMock;
+    private MessageManagerInterface|MockObject $messageManagerMock;
+    private MockObject|BulkPublisherInterface $publisherMock;
+    private MockObject|SchedulerInterface $entitySchedulerMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpLegacy($this);
+
+        $this->eventManagerMock = $this->getMockBuilder(ManagerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $this->messageManagerMock = $this->getMockBuilder(MessageManagerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $this->publisherMock = $this->getMockBuilder(BulkPublisherInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $this->entitySchedulerMock = $this->getMockBuilder(SchedulerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownLegacy($this);
+        parent::tearDown();
+    }
+
+    /**
+     * @requires PHP <8.2.0
+     * @group legacy
+     * @dataProvider provideLegacyPropertiesPhp81
+     */
+    #[RequiresPhp('<8.2.0')]
+    public function testAccessingDeprecatedPropertiesPhp81(string $property, mixed $newPropertyValue, array $deprecationsTriggered): void
+    {
+        $model = new TestFixtureSubActionAbstractLegacy(
+            $this->eventManagerMock,
+            $this->messageManagerMock,
+            $this->publisherMock,
+            $this->entitySchedulerMock
+        );
+
+        $this->assertLegacyProperty($property, $newPropertyValue, $model, $this, $deprecationsTriggered);
+    }
+
+    public function provideLegacyPropertiesPhp81(): array
+    {
+        return [
+            'eventManager' => [
+                'eventManager',
+                $this->getMockBuilder(ManagerInterface::class)
+                    ->disableOriginalConstructor()
+                    ->getMockForAbstractClass(),
+                [
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::eventManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::eventManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::eventManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::eventManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::eventManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::eventManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                ]
+            ],
+            'messageManager' => [
+                'messageManager',
+                $this->getMockBuilder(MessageManagerInterface::class)
+                    ->disableOriginalConstructor()
+                    ->getMockForAbstractClass(),
+                [
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::messageManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::messageManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::messageManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::messageManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::messageManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::messageManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                ]
+            ],
+            'publisher' => [
+                'publisher',
+                $this->getMockBuilder(BulkPublisherInterface::class)
+                    ->disableOriginalConstructor()
+                    ->getMockForAbstractClass(),
+                [
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::publisher has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::publisher has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::publisher has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::publisher has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::publisher has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::publisher has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                ]
+            ],
+            'entityScheduler' => [
+                'entityScheduler',
+                $this->getMockBuilder(SchedulerInterface::class)
+                    ->disableOriginalConstructor()
+                    ->getMockForAbstractClass(),
+                [
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::entityScheduler has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::entityScheduler has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::entityScheduler has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::entityScheduler has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::entityScheduler has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::entityScheduler has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                ]
+            ],
+
+        ];
+    }
+
+    /**
+     * @requires PHP >=8.2.0
+     * @group legacy
+     * @dataProvider provideLegacyPropertiesPhp82
+     */
+    #[RequiresPhp('>=8.2.0')]
+    public function testAccessingDeprecatedPropertiesPhp82(string $property, mixed $newPropertyValue, array $deprecationsTriggered): void
+    {
+        $model = new TestFixtureSubActionAbstractLegacy(
+            $this->eventManagerMock,
+            $this->messageManagerMock,
+            $this->publisherMock,
+            $this->entitySchedulerMock
+        );
+
+        $this->assertLegacyProperty($property, $newPropertyValue, $model, $this, $deprecationsTriggered);
+    }
+
+    public function provideLegacyPropertiesPhp82(): array
+    {
+        return [
+            'eventManager' => [
+                'eventManager',
+                $this->getMockBuilder(ManagerInterface::class)
+                    ->disableOriginalConstructor()
+                    ->getMockForAbstractClass(),
+                [
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::eventManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::eventManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Creation of dynamic property via __set(): HawkSearch\EsIndexing\Test\Unit\Model\Indexer\Entities\TestFixtureSubActionAbstractLegacy::\$eventManager is deprecated",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::eventManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::eventManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::eventManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::eventManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                ]
+            ],
+            'messageManager' => [
+                'messageManager',
+                $this->getMockBuilder(MessageManagerInterface::class)
+                    ->disableOriginalConstructor()
+                    ->getMockForAbstractClass(),
+                [
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::messageManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::messageManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Creation of dynamic property via __set(): HawkSearch\EsIndexing\Test\Unit\Model\Indexer\Entities\TestFixtureSubActionAbstractLegacy::\$messageManager is deprecated",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::messageManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::messageManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::messageManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::messageManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                ]
+            ],
+            'publisher' => [
+                'publisher',
+                $this->getMockBuilder(BulkPublisherInterface::class)
+                    ->disableOriginalConstructor()
+                    ->getMockForAbstractClass(),
+                [
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::publisher has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::publisher has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Creation of dynamic property via __set(): HawkSearch\EsIndexing\Test\Unit\Model\Indexer\Entities\TestFixtureSubActionAbstractLegacy::\$publisher is deprecated",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::publisher has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::publisher has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::publisher has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::publisher has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                ]
+            ],
+            'entityScheduler' => [
+                'entityScheduler',
+                $this->getMockBuilder(SchedulerInterface::class)
+                    ->disableOriginalConstructor()
+                    ->getMockForAbstractClass(),
+                [
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::entityScheduler has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::entityScheduler has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Creation of dynamic property via __set(): HawkSearch\EsIndexing\Test\Unit\Model\Indexer\Entities\TestFixtureSubActionAbstractLegacy::\$entityScheduler is deprecated",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::entityScheduler has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::entityScheduler has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::entityScheduler has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\ActionAbstract::entityScheduler has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                ]
+            ],
+
+        ];
+    }
+}
+
+/**
+ * @group legacy
+ */
+class TestFixtureSubActionAbstractLegacy extends ActionAbstract
+{
+    use AccessClassPropertyFixtureTrait;
+
+    public function execute(array $ids): self
+    {
+        return $this;
+    }
+}

--- a/Test/Unit/Model/Indexer/Entities/SchedulerCompositeTest.php
+++ b/Test/Unit/Model/Indexer/Entities/SchedulerCompositeTest.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Copyright (c) 2025 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Test\Unit\Model\Indexer\Entities;
+
+use HawkSearch\Connector\Test\Unit\Compatibility\Fixtures\AccessClassPropertyFixtureTrait;
+use HawkSearch\Connector\Test\Unit\Compatibility\LegacyBaseTrait;
+use HawkSearch\EsIndexing\Model\Indexer\Entities\SchedulerComposite;
+use Magento\Framework\ObjectManager\TMap;
+use Magento\Framework\ObjectManager\TMapFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class SchedulerCompositeTest extends TestCase
+{
+    use LegacyBaseTrait;
+
+    private TMapFactory|MockObject $tmapFactoryMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpLegacy($this);
+
+        $this->tmapFactoryMock = $this->getMockBuilder(TMapFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->tmapFactoryMock->expects($this->any())->method('create')
+            ->willReturn($this->getMockBuilder(TMap::class)
+                ->disableOriginalConstructor()
+                ->getMock()
+            );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownLegacy($this);
+        parent::tearDown();
+    }
+
+    /**
+     * @requires PHP <8.2.0
+     * @group legacy
+     * @dataProvider provideLegacyPropertiesPhp81
+     */
+    #[RequiresPhp('<8.2.0')]
+    public function testAccessingDeprecatedPropertiesPhp81(string $property, mixed $newPropertyValue, array $deprecationsTriggered): void
+    {
+        $model = new TestFixtureSubSchedulerCompositeLegacy(
+            $this->tmapFactoryMock,
+            []
+        );
+
+        $this->assertLegacyProperty($property, $newPropertyValue, $model, $this, $deprecationsTriggered);
+    }
+
+    public function provideLegacyPropertiesPhp81(): array
+    {
+        return [
+            'schedulers' => [
+                'schedulers',
+                $this->getMockBuilder(TMap::class)
+                    ->disableOriginalConstructor()
+                    ->addMethods(['fakeMethod'])
+                    ->getMock(),
+                [
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\SchedulerComposite::schedulers has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\SchedulerComposite::schedulers has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\SchedulerComposite::schedulers has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\SchedulerComposite::schedulers has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\SchedulerComposite::schedulers has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\SchedulerComposite::schedulers has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                ]
+            ],
+        ];
+    }
+
+    /**
+     * @requires PHP >=8.2.0
+     * @group legacy
+     * @dataProvider provideLegacyPropertiesPhp82
+     */
+    #[RequiresPhp('>=8.2.0')]
+    public function testAccessingDeprecatedPropertiesPhp82(string $property, mixed $newPropertyValue, array $deprecationsTriggered): void
+    {
+        $model = new TestFixtureSubSchedulerCompositeLegacy(
+            $this->tmapFactoryMock,
+            []
+        );
+
+        $this->assertLegacyProperty($property, $newPropertyValue, $model, $this, $deprecationsTriggered);
+    }
+
+    public function provideLegacyPropertiesPhp82(): array
+    {
+        return [
+            'schedulers' => [
+                'schedulers',
+                $this->getMockBuilder(TMap::class)
+                    ->disableOriginalConstructor()
+                    ->addMethods(['fakeMethod'])
+                    ->getMock(),
+                [
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\SchedulerComposite::schedulers has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\SchedulerComposite::schedulers has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Creation of dynamic property via __set(): HawkSearch\EsIndexing\Test\Unit\Model\Indexer\Entities\TestFixtureSubSchedulerCompositeLegacy::\$schedulers is deprecated",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\SchedulerComposite::schedulers has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\SchedulerComposite::schedulers has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\SchedulerComposite::schedulers has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexer\Entities\SchedulerComposite::schedulers has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                ]
+            ],
+        ];
+    }
+}
+
+class TestFixtureSubSchedulerCompositeLegacy extends SchedulerComposite
+{
+    use AccessClassPropertyFixtureTrait;
+}

--- a/Test/Unit/Model/Indexing/AbstractEntityRebuildTest.php
+++ b/Test/Unit/Model/Indexing/AbstractEntityRebuildTest.php
@@ -1,0 +1,295 @@
+<?php
+/**
+ * Copyright (c) 2025 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Test\Unit\Model\Indexing;
+
+use HawkSearch\Connector\Logger\LoggerFactoryInterface;
+use HawkSearch\Connector\Test\Unit\Compatibility\Fixtures\AccessClassPropertyFixtureTrait;
+use HawkSearch\Connector\Test\Unit\Compatibility\LegacyBaseTrait;
+use HawkSearch\EsIndexing\Helper\ObjectHelper;
+use HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild;
+use HawkSearch\EsIndexing\Model\Indexing\ContextInterface;
+use HawkSearch\EsIndexing\Model\Indexing\EntityTypePoolInterface;
+use Magento\Framework\DataObject;
+use Magento\Framework\Event\ManagerInterface as EventManagerInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class AbstractEntityRebuildTest extends TestCase
+{
+    use LegacyBaseTrait;
+
+    private MockObject|EntityTypePoolInterface $entityTypePoolMock;
+    private EventManagerInterface|MockObject $eventManagerMock;
+    private MockObject|LoggerFactoryInterface $loggerFactoryMock;
+    private MockObject|StoreManagerInterface $storeManagerMock;
+    private MockObject|ContextInterface $indexingContextMock;
+    private ObjectHelper|MockObject $objectHelperMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpLegacy($this);
+
+        $this->entityTypePoolMock = $this->getMockBuilder(EntityTypePoolInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $this->eventManagerMock = $this->getMockBuilder(EventManagerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $this->loggerFactoryMock = $this->getMockBuilder(LoggerFactoryInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $this->storeManagerMock = $this->getMockBuilder(StoreManagerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $this->indexingContextMock = $this->getMockBuilder(ContextInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $this->objectHelperMock = $this->getMockBuilder(ObjectHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->loggerFactoryMock->expects($this->any())->method('create')
+            ->willReturn($this->getMockBuilder(LoggerInterface::class)
+                ->disableOriginalConstructor()
+                ->getMockForAbstractClass()
+            );
+        $this->setUpBeforeClass();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownLegacy($this);
+        parent::tearDown();
+    }
+
+    /**
+     * @requires PHP <8.2.0
+     * @group legacy
+     * @dataProvider provideLegacyPropertiesPhp81
+     */
+    #[RequiresPhp('<8.2.0')]
+    public function testAccessingDeprecatedPropertiesPhp81(string $property, mixed $newPropertyValue, array $deprecationsTriggered): void
+    {
+        $model = new TestFixtureSubAbstractEntityRebuildLegacy(
+            $this->entityTypePoolMock,
+            $this->eventManagerMock,
+            $this->loggerFactoryMock,
+            $this->storeManagerMock,
+            $this->indexingContextMock,
+            $this->objectHelperMock
+        );
+
+        $newPropertyValue = $newPropertyValue instanceof \Closure ? $newPropertyValue->bindTo($this)() : $newPropertyValue;
+
+        $this->assertLegacyProperty($property, $newPropertyValue, $model, $this, $deprecationsTriggered);
+    }
+
+    public function provideLegacyPropertiesPhp81(): array
+    {
+        return [
+            'entityTypePool' => [
+                'entityTypePool',
+                $this->getMockBuilder(EntityTypePoolInterface::class)
+                    ->disableOriginalConstructor()
+                    ->getMockForAbstractClass(),
+                [
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::entityTypePool has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::entityTypePool has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::entityTypePool has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::entityTypePool has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::entityTypePool has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::entityTypePool has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                ]
+            ],
+            'eventManager' => [
+                'eventManager',
+                $this->getMockBuilder(EventManagerInterface::class)
+                    ->disableOriginalConstructor()
+                    ->getMockForAbstractClass(),
+                [
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::eventManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::eventManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::eventManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::eventManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::eventManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::eventManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                ]
+            ],
+            'hawkLogger' => [
+                'hawkLogger',
+                function (): object {
+                    return clone $this->loggerFactoryMock->create();
+                },
+                [
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::hawkLogger has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via \$loggerFactory constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::hawkLogger has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via \$loggerFactory constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::hawkLogger has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via \$loggerFactory constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::hawkLogger has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via \$loggerFactory constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::hawkLogger has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via \$loggerFactory constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::hawkLogger has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via \$loggerFactory constructor injection.",
+                ]
+            ],
+            'storeManager' => [
+                'storeManager',
+                $this->getMockBuilder(StoreManagerInterface::class)
+                    ->disableOriginalConstructor()
+                    ->getMockForAbstractClass(),
+                [
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::storeManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::storeManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::storeManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::storeManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::storeManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::storeManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                ]
+            ],
+            'indexingContext' => [
+                'indexingContext',
+                $this->getMockBuilder(ContextInterface::class)
+                    ->disableOriginalConstructor()
+                    ->getMockForAbstractClass(),
+                [
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::indexingContext has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::indexingContext has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::indexingContext has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::indexingContext has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::indexingContext has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::indexingContext has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @requires PHP >=8.2.0
+     * @group legacy
+     * @dataProvider provideLegacyPropertiesPhp82
+     */
+    #[RequiresPhp('>=8.2.0')]
+    public function testAccessingDeprecatedPropertiesPhp82(string $property, mixed $newPropertyValue, array $deprecationsTriggered): void
+    {
+        $model = new TestFixtureSubAbstractEntityRebuildLegacy(
+            $this->entityTypePoolMock,
+            $this->eventManagerMock,
+            $this->loggerFactoryMock,
+            $this->storeManagerMock,
+            $this->indexingContextMock,
+            $this->objectHelperMock
+        );
+
+        $newPropertyValue = $newPropertyValue instanceof \Closure ? $newPropertyValue->bindTo($this)() : $newPropertyValue;
+
+        $this->assertLegacyProperty($property, $newPropertyValue, $model, $this, $deprecationsTriggered);
+    }
+
+    public function provideLegacyPropertiesPhp82(): array
+    {
+        return [
+            'entityTypePool' => [
+                'entityTypePool',
+                $this->getMockBuilder(EntityTypePoolInterface::class)
+                    ->disableOriginalConstructor()
+                    ->getMockForAbstractClass(),
+                [
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::entityTypePool has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::entityTypePool has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Creation of dynamic property via __set(): HawkSearch\EsIndexing\Test\Unit\Model\Indexing\TestFixtureSubAbstractEntityRebuildLegacy::\$entityTypePool is deprecated",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::entityTypePool has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::entityTypePool has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::entityTypePool has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::entityTypePool has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                ]
+            ],
+            'eventManager' => [
+                'eventManager',
+                $this->getMockBuilder(EventManagerInterface::class)
+                    ->disableOriginalConstructor()
+                    ->getMockForAbstractClass(),
+                [
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::eventManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::eventManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Creation of dynamic property via __set(): HawkSearch\EsIndexing\Test\Unit\Model\Indexing\TestFixtureSubAbstractEntityRebuildLegacy::\$eventManager is deprecated",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::eventManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::eventManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::eventManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::eventManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                ]
+            ],
+            'hawkLogger' => [
+                'hawkLogger',
+                function (): object {
+                    return clone $this->loggerFactoryMock->create();
+                },
+                [
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::hawkLogger has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via \$loggerFactory constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::hawkLogger has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via \$loggerFactory constructor injection.",
+                    "Creation of dynamic property via __set(): HawkSearch\EsIndexing\Test\Unit\Model\Indexing\TestFixtureSubAbstractEntityRebuildLegacy::\$hawkLogger is deprecated",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::hawkLogger has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via \$loggerFactory constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::hawkLogger has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via \$loggerFactory constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::hawkLogger has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via \$loggerFactory constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::hawkLogger has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via \$loggerFactory constructor injection.",
+                ]
+            ],
+            'storeManager' => [
+                'storeManager',
+                $this->getMockBuilder(StoreManagerInterface::class)
+                    ->disableOriginalConstructor()
+                    ->getMockForAbstractClass(),
+                [
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::storeManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::storeManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Creation of dynamic property via __set(): HawkSearch\EsIndexing\Test\Unit\Model\Indexing\TestFixtureSubAbstractEntityRebuildLegacy::\$storeManager is deprecated",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::storeManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::storeManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::storeManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::storeManager has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                ]
+            ],
+            'indexingContext' => [
+                'indexingContext',
+                $this->getMockBuilder(ContextInterface::class)
+                    ->disableOriginalConstructor()
+                    ->getMockForAbstractClass(),
+                [
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::indexingContext has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::indexingContext has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Creation of dynamic property via __set(): HawkSearch\EsIndexing\Test\Unit\Model\Indexing\TestFixtureSubAbstractEntityRebuildLegacy::\$indexingContext is deprecated",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::indexingContext has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::indexingContext has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::indexingContext has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                    "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\AbstractEntityRebuild::indexingContext has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+                ]
+            ]
+        ];
+    }
+}
+
+class TestFixtureSubAbstractEntityRebuildLegacy extends AbstractEntityRebuild
+{
+    use AccessClassPropertyFixtureTrait;
+
+    protected function isAllowedItem(DataObject $item): bool
+    {
+        return false;
+    }
+
+    protected function getEntityId(DataObject $entityItem): ?int
+    {
+        return null;
+    }
+}

--- a/Test/Unit/Model/Indexing/FieldHandler/CompositeTest.php
+++ b/Test/Unit/Model/Indexing/FieldHandler/CompositeTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Copyright (c) 2025 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Test\Unit\Model\Indexing\FieldHandler;
+
+use HawkSearch\Connector\Test\Unit\Compatibility\Fixtures\AccessClassPropertyFixtureTrait;
+use HawkSearch\Connector\Test\Unit\Compatibility\LegacyBaseTrait;
+use HawkSearch\EsIndexing\Model\Indexing\FieldHandler\Composite;
+use Magento\Framework\App\ObjectManager;
+use PHPUnit\Framework\TestCase;
+
+class CompositeTest extends TestCase
+{
+    use LegacyBaseTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpLegacy($this);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownLegacy($this);
+        parent::tearDown();
+    }
+
+    /**
+     * @requires PHP <8.2.0
+     * @group legacy
+     */
+    #[RequiresPhp('<8.2.0')]
+    public function testAccessingDeprecatedPropertiesPhp81(): void
+    {
+        $model = new TestFixtureSubCompositeLegacy(ObjectManager::getInstance(), []);
+
+        $this->assertLegacyProperty('handlers', [], $model, $this, [
+            "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\FieldHandler\Composite::handlers has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+            "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\FieldHandler\Composite::handlers has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+            "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\FieldHandler\Composite::handlers has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+            "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\FieldHandler\Composite::handlers has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+            "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\FieldHandler\Composite::handlers has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+            "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\FieldHandler\Composite::handlers has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+        ]);
+    }
+
+    /**
+     * @requires PHP >=8.2.0
+     * @group legacy
+     */
+    #[RequiresPhp('>=8.2.0')]
+    public function testAccessingDeprecatedPropertiesPhp82(): void
+    {
+        $model = new TestFixtureSubCompositeLegacy(ObjectManager::getInstance(), []);
+
+        $this->assertLegacyProperty('handlers', [], $model, $this, [
+            "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\FieldHandler\Composite::handlers has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+            "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\FieldHandler\Composite::handlers has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+            "Creation of dynamic property via __set(): HawkSearch\EsIndexing\Test\Unit\Model\Indexing\FieldHandler\TestFixtureSubCompositeLegacy::\$handlers is deprecated",
+            "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\FieldHandler\Composite::handlers has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+            "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\FieldHandler\Composite::handlers has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+            "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\FieldHandler\Composite::handlers has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+            "Since 0.8.0: Property HawkSearch\EsIndexing\Model\Indexing\FieldHandler\Composite::handlers has been deprecated and it's public/protected usage will be discontinued. Visibility changed to private. Set via constructor injection.",
+        ]);
+    }
+}
+
+/**
+ * @group legacy
+ */
+class TestFixtureSubCompositeLegacy extends Composite
+{
+    use AccessClassPropertyFixtureTrait;
+}

--- a/Test/Unit/Model/Product/ProductType/BundleTest.php
+++ b/Test/Unit/Model/Product/ProductType/BundleTest.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Copyright (c) 2025 Hawksearch (www.hawksearch.com) - All Rights Reserved
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+declare(strict_types=1);
+
+namespace HawkSearch\EsIndexing\Test\Unit\Model\Product\ProductType;
+
+use HawkSearch\Connector\Test\Unit\Compatibility\Fixtures\AccessClassPropertyFixtureTrait;
+use HawkSearch\Connector\Test\Unit\Compatibility\LegacyBaseTrait;
+use HawkSearch\EsIndexing\Helper\PricingHelper;
+use HawkSearch\EsIndexing\Model\Product\ProductType\Bundle;
+use Magento\Customer\Api\GroupManagementInterface;
+use Magento\Customer\Model\Customer\Source\GroupSourceInterface;
+use Magento\Framework\Module\Manager as ModuleManager;
+use Magento\Framework\Pricing\PriceCurrencyInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class BundleTest extends TestCase
+{
+    use LegacyBaseTrait;
+
+    private PriceCurrencyInterface|MockObject $priceCurrencyMock;
+    private MockObject|GroupSourceInterface $customerGroupSourceMock;
+    private GroupManagementInterface|MockObject $groupManagementMock;
+    private ModuleManager|MockObject $moduleManagerMock;
+    private MockObject|PricingHelper $pricingHelperMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpLegacy($this);
+
+        $this->priceCurrencyMock = $this->getMockBuilder(PriceCurrencyInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $this->customerGroupSourceMock = $this->getMockBuilder(GroupSourceInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $this->groupManagementMock = $this->getMockBuilder(GroupManagementInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $this->moduleManagerMock = $this->getMockBuilder(ModuleManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->pricingHelperMock = $this->getMockBuilder(PricingHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownLegacy($this);
+        parent::tearDown();
+    }
+
+    /**
+     * @requires PHP <8.2.0
+     * @group legacy
+     * @dataProvider provideLegacyPropertiesPhp81
+     */
+    #[RequiresPhp('<8.2.0')]
+    public function testAccessingDeprecatedPropertiesPhp81(string $property, mixed $newPropertyValue, array $deprecationsTriggered): void
+    {
+        $model = new TestFixtureSubBundleLegacy(
+            $this->priceCurrencyMock,
+            $this->customerGroupSourceMock,
+            $this->groupManagementMock,
+            $this->moduleManagerMock,
+            $this->pricingHelperMock
+        );
+
+        $newPropertyValue = $newPropertyValue instanceof \Closure ? $newPropertyValue->bindTo($this)() : $newPropertyValue;
+
+        $this->assertLegacyProperty($property, $newPropertyValue, $model, $this, $deprecationsTriggered);
+    }
+
+    public function provideLegacyPropertiesPhp81(): array
+    {
+        return [
+            'keySelectionsCollection' => [
+                'keySelectionsCollection',
+                'test string',
+                [
+                    "Since 0.7.0: Property HawkSearch\EsIndexing\Model\Product\ProductType\Bundle::keySelectionsCollection has been deprecated and it's public/protected usage will be discontinued. Property will be removed.",
+                    "Since 0.7.0: Property HawkSearch\EsIndexing\Model\Product\ProductType\Bundle::keySelectionsCollection has been deprecated and it's public/protected usage will be discontinued. Property will be removed.",
+                    "Since 0.7.0: Property HawkSearch\EsIndexing\Model\Product\ProductType\Bundle::keySelectionsCollection has been deprecated and it's public/protected usage will be discontinued. Property will be removed.",
+                    "Since 0.7.0: Property HawkSearch\EsIndexing\Model\Product\ProductType\Bundle::keySelectionsCollection has been deprecated and it's public/protected usage will be discontinued. Property will be removed.",
+                    "Since 0.7.0: Property HawkSearch\EsIndexing\Model\Product\ProductType\Bundle::keySelectionsCollection has been deprecated and it's public/protected usage will be discontinued. Property will be removed.",
+                    "Since 0.7.0: Property HawkSearch\EsIndexing\Model\Product\ProductType\Bundle::keySelectionsCollection has been deprecated and it's public/protected usage will be discontinued. Property will be removed.",
+                ]
+            ],
+        ];
+    }
+
+    /**
+     * @requires PHP >=8.2.0
+     * @group legacy
+     * @dataProvider provideLegacyPropertiesPhp82
+     */
+    #[RequiresPhp('>=8.2.0')]
+    public function testAccessingDeprecatedPropertiesPhp82(string $property, mixed $newPropertyValue, array $deprecationsTriggered): void
+    {
+        $model = new TestFixtureSubBundleLegacy(
+            $this->priceCurrencyMock,
+            $this->customerGroupSourceMock,
+            $this->groupManagementMock,
+            $this->moduleManagerMock,
+            $this->pricingHelperMock
+        );
+
+        $newPropertyValue = $newPropertyValue instanceof \Closure ? $newPropertyValue->bindTo($this)() : $newPropertyValue;
+
+        $this->assertLegacyProperty($property, $newPropertyValue, $model, $this, $deprecationsTriggered);
+    }
+
+    public function provideLegacyPropertiesPhp82(): array
+    {
+        return [
+            'keySelectionsCollection' => [
+                'keySelectionsCollection',
+                'test string',
+                [
+                    "Since 0.7.0: Property HawkSearch\EsIndexing\Model\Product\ProductType\Bundle::keySelectionsCollection has been deprecated and it's public/protected usage will be discontinued. Property will be removed.",
+                    "Since 0.7.0: Property HawkSearch\EsIndexing\Model\Product\ProductType\Bundle::keySelectionsCollection has been deprecated and it's public/protected usage will be discontinued. Property will be removed.",
+                    "Creation of dynamic property via __set(): HawkSearch\EsIndexing\Test\Unit\Model\Product\ProductType\TestFixtureSubBundleLegacy::\$keySelectionsCollection is deprecated",
+                    "Since 0.7.0: Property HawkSearch\EsIndexing\Model\Product\ProductType\Bundle::keySelectionsCollection has been deprecated and it's public/protected usage will be discontinued. Property will be removed.",
+                    "Since 0.7.0: Property HawkSearch\EsIndexing\Model\Product\ProductType\Bundle::keySelectionsCollection has been deprecated and it's public/protected usage will be discontinued. Property will be removed.",
+                    "Since 0.7.0: Property HawkSearch\EsIndexing\Model\Product\ProductType\Bundle::keySelectionsCollection has been deprecated and it's public/protected usage will be discontinued. Property will be removed.",
+                    "Since 0.7.0: Property HawkSearch\EsIndexing\Model\Product\ProductType\Bundle::keySelectionsCollection has been deprecated and it's public/protected usage will be discontinued. Property will be removed.",
+                ]
+            ],
+        ];
+    }
+}
+
+class TestFixtureSubBundleLegacy extends Bundle
+{
+    use AccessClassPropertyFixtureTrait;
+}

--- a/UPGRADE-0.8.md
+++ b/UPGRADE-0.8.md
@@ -1,0 +1,14 @@
+# UPGRADE FROM 0.7 to 0.8
+
+- Usage of protected property `Block\Adminhtml\System\Config\Product\CustomAttributes::columnRendererCache` is deprecated. Visibility will be changed to private in version 1.0.
+- Usage of protected property `Model\Indexer\Entities\ActionAbstract::eventManager` is deprecated. Visibility will be changed to private in version 1.0. Set via constructor injection.
+- Usage of protected property `Model\Indexer\Entities\ActionAbstract::messageManager` is deprecated. Visibility will be changed to private in version 1.0. Set via constructor injection.
+- Usage of protected property `Model\Indexer\Entities\ActionAbstract::publisher` is deprecated. Visibility will be changed to private in version 1.0. Set via constructor injection.
+- Usage of protected property `Model\Indexer\Entities\ActionAbstract::entityScheduler` is deprecated. Visibility will be changed to private in version 1.0. Set via constructor injection.
+- Usage of protected property `Model\Indexer\Entities\SchedulerComposite::schedulers` is deprecated. Visibility will be changed to private in version 1.0. Set via constructor injection.
+- Usage of protected property `Model\Indexing\AbstractEntityRebuild::entityTypePool` is deprecated. Visibility will be changed to private in version 1.0. Set via constructor injection.
+- Usage of protected property `Model\Indexing\AbstractEntityRebuild::eventManager` is deprecated. Visibility will be changed to private in version 1.0. Set via constructor injection.
+- Usage of protected property `Model\Indexing\AbstractEntityRebuild::hawkLogger` is deprecated. Visibility will be changed to private in version 1.0. Set via `$loggerFactory` constructor injection.
+- Usage of protected property `Model\Indexing\AbstractEntityRebuild::storeManager` is deprecated. Visibility will be changed to private in version 1.0. Set via constructor injection.
+- Usage of protected property `Model\Indexing\AbstractEntityRebuild::indexingContext` is deprecated. Visibility will be changed to private in version 1.0. Set via constructor injection.
+- Usage of protected property `Model\Indexing\FieldHandler\Composite::handlers` is deprecated. Visibility will be changed to private in version 1.0. Set via constructor injection.

--- a/UPGRADE-1.0.md
+++ b/UPGRADE-1.0.md
@@ -1,0 +1,14 @@
+# UPGRADE FROM 0.x to 1.0
+
+- Protected property `Block\Adminhtml\System\Config\Product\CustomAttributes::columnRendererCache` visibility has been changed to `private`.
+- Protected property `Model\Indexer\Entities\ActionAbstract::eventManager` visibility has been changed to `private`. Set via constructor injection.
+- Protected property `Model\Indexer\Entities\ActionAbstract::messageManager` visibility has been changed to `private`. Set via constructor injection.
+- Protected property `Model\Indexer\Entities\ActionAbstract::publisher` visibility has been changed to `private`. Set via constructor injection.
+- Protected property `Model\Indexer\Entities\ActionAbstract::entityScheduler` visibility has been changed to `private`. Set via constructor injection.
+- Protected property `Model\Indexer\Entities\SchedulerComposite::schedulers` visibility has been changed to `private`. Set via constructor injection.
+- Protected property `Model\Indexing\AbstractEntityRebuild::entityTypePool` visibility has been changed to `private`. Set via constructor injection.
+- Protected property `Model\Indexing\AbstractEntityRebuild::eventManager` visibility has been changed to `private`. Set via constructor injection.
+- Protected property `Model\Indexing\AbstractEntityRebuild::hawkLogger` visibility has been changed to `private`. Set via `$loggerFactory` constructor injection.
+- Protected property `Model\Indexing\AbstractEntityRebuild::storeManager` visibility has been changed to `private`. Set via constructor injection.
+- Protected property `Model\Indexing\AbstractEntityRebuild::indexingContext` visibility has been changed to `private`. Set via constructor injection.
+- Protected property `Model\Indexing\FieldHandler\Composite::handlers` visibility has been changed to `private`. Set via constructor injection.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 0.8 
| Bug fix?      | no <!-- please update CHANGELOG-*.md file -->
| New feature?  | no <!-- please update CHANGELOG-*.md file -->
| Deprecations? | yes
| Tests pass?| yes
| Issues        | Fix HC-1706 


This PR makes  triggering a deprecation when protected property in a child class is accessed while the same property in  the parent class has changed its visibility to private.

The goal here is to be able to add types to all properties in 1.0, thus fixing

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained stable branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too). Lowest stable is `master` now.
 - Features and deprecations must be submitted against the latest branch. Latest is a branch for active development.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow (doc link will be added later)
 - Never break backward compatibility (see https://developerdocs.hawksearch.com/docs/magento-developers-bc-policy).
-->
