### PR TITLE
feat: add argument types to private methods 

### DIFF
--- a/Api/HierarchyManagementInterface.php
+++ b/Api/HierarchyManagementInterface.php
@@ -24,6 +24,7 @@ interface HierarchyManagementInterface
 {
     /**
      * @param list<array<string, mixed>> $items
+     * @param string $indexName
      * @return void
      * @todo use \HawkSearch\EsIndexing\Api\Data\HierarchyInterface[] as input array
      */
@@ -36,6 +37,7 @@ interface HierarchyManagementInterface
 
     /**
      * @param string[] $ids
+     * @param string $indexName
      * @return void
      */
     public function deleteHierarchyItems(array $ids, string $indexName);

--- a/Model/Config/Source/HawksearchFields.php
+++ b/Model/Config/Source/HawksearchFields.php
@@ -20,14 +20,16 @@ use Magento\Framework\Data\OptionSourceInterface;
 
 class HawksearchFields implements OptionSourceInterface
 {
-    private ?array $fieldsCache = null;
+    /**
+     * @var FieldInterface[]
+     */
+    private array $fieldsCache;
     private FieldManagementInterface $fieldManagement;
 
     public function __construct(
         FieldManagementInterface $fieldManagement
 
-    )
-    {
+    ) {
         $this->fieldManagement = $fieldManagement;
     }
 
@@ -56,7 +58,7 @@ class HawksearchFields implements OptionSourceInterface
      */
     private function getFields(): array
     {
-        if ($this->fieldsCache === null) {
+        if (!isset($this->fieldsCache)) {
             $this->fieldsCache = $this->fieldManagement->getFields();
         }
 

--- a/Model/Field/Product/AttributeProvider.php
+++ b/Model/Field/Product/AttributeProvider.php
@@ -24,6 +24,9 @@ use Magento\Framework\Exception\NoSuchEntityException;
  */
 class AttributeProvider
 {
+    /**
+     * @var array<string, AttributeAdapter>
+     */
     private array $cachedAttributes = [];
     private ProductAttributeRepositoryInterface $productAttributeRepository;
     private ProductAttributeInterfaceFactory $productAttributeFactory;
@@ -33,8 +36,7 @@ class AttributeProvider
         ProductAttributeRepositoryInterface $productAttributeRepository,
         ProductAttributeInterfaceFactory $productAttributeFactory,
         string $instanceName = AttributeAdapter::class
-    )
-    {
+    ) {
         $this->productAttributeRepository = $productAttributeRepository;
         $this->productAttributeFactory = $productAttributeFactory;
         $this->instanceName = $instanceName;

--- a/Model/Indexing/AbstractEntityRebuild.php
+++ b/Model/Indexing/AbstractEntityRebuild.php
@@ -73,7 +73,13 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
             'description' => 'Visibility changed to private. Set via constructor injection.'
         ],
     ];
+    /**
+     * @var array<string, int>
+     */
     private array $itemsToRemoveCache = [];
+    /**
+     * @var array<string, int>
+     */
     private array $itemsToIndexCache = [];
     private EntityTypeInterface $entityType;
 
@@ -121,8 +127,7 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
         StoreManagerInterface $storeManager,
         ContextInterface $indexingContext,
         ObjectHelper $objectHelper
-    )
-    {
+    ) {
         $this->entityTypePool = $entityTypePool;
         $this->eventManager = $eventManager;
         $this->hawkLogger = $loggerFactory->create();

--- a/Model/Indexing/Context.php
+++ b/Model/Indexing/Context.php
@@ -16,6 +16,9 @@ namespace HawkSearch\EsIndexing\Model\Indexing;
 
 class Context implements ContextInterface
 {
+    /**
+     * @var array<int, string>
+     */
     private array $indexNameCache = [];
     private bool $isFullReindex = false;
 

--- a/Model/Indexing/Entity/LandingPage/EntityRebuild.php
+++ b/Model/Indexing/Entity/LandingPage/EntityRebuild.php
@@ -49,7 +49,13 @@ class EntityRebuild extends AbstractEntityRebuild
      * @var LandingPageInterface[]
      */
     private array $landingPages;
+    /**
+     * @var array<string, LandingPageInterface>
+     */
     private array $customFieldMap;
+    /**
+     * @var array<string, LandingPageInterface>
+     */
     private array $customUrlMap;
     private Cache $cache;
     private SerializerInterface $serializer;
@@ -82,8 +88,7 @@ class EntityRebuild extends AbstractEntityRebuild
         LandingPageManagementInterface $landingPageManagement,
         LandingPageInterfaceFactory $landingPageFactory,
         CustomUrl $customUrlHandler
-    )
-    {
+    ) {
         parent::__construct(
             $entityTypePool,
             $eventManager,

--- a/Model/Product/Attributes.php
+++ b/Model/Product/Attributes.php
@@ -26,6 +26,10 @@ use Magento\Framework\Serialize\Serializer\Json;
  */
 class Attributes
 {
+
+    /**
+     * @var array<string, string>
+     */
     private array $attributes;
     private Config $eavConfig;
     private Json $jsonSerializer;
@@ -35,8 +39,7 @@ class Attributes
         Config $eavConfig,
         Json $jsonSerializer,
         ProductsConfig $attributesConfigProvider
-    )
-    {
+    ) {
         $this->eavConfig = $eavConfig;
         $this->jsonSerializer = $jsonSerializer;
         $this->attributesConfigProvider = $attributesConfigProvider;

--- a/Observer/SendCookieOnCartCompleteObserver.php
+++ b/Observer/SendCookieOnCartCompleteObserver.php
@@ -41,7 +41,7 @@ class SendCookieOnCartCompleteObserver implements ObserverInterface
     private CookieManagerInterface $cookieManager;
 
     /**
-     * @var HttpRequest
+     * @var HttpRequest|RequestInterface
      */
     private RequestInterface $httpRequest;
 
@@ -56,8 +56,7 @@ class SendCookieOnCartCompleteObserver implements ObserverInterface
         CookieManagerInterface $cookieManager,
         RequestInterface $httpRequest,
         SerializerInterface $jsonSerializer
-    )
-    {
+    ) {
         $this->cartItemsToAddDataStorage = $cartItemsToAddDataStorage;
         $this->cartItemsToRemoveDataStorage = $cartItemsToRemoveDataStorage;
         $this->eventTrackingConfig = $eventTrackingConfig;

--- a/Plugin/Eav/Entity/Attribute/Source/Table/SpecificOptionsPlugin.php
+++ b/Plugin/Eav/Entity/Attribute/Source/Table/SpecificOptionsPlugin.php
@@ -17,12 +17,12 @@ namespace HawkSearch\EsIndexing\Plugin\Eav\Entity\Attribute\Source\Table;
 use Magento\Eav\Model\Entity\Attribute\Source\Table;
 
 /**
-* Performance workaround for issue https://github.com/magento/magento2/issues/38934
-* Please note this around plugin doesn't call $proceed callable,
-* and it will prevent the execution of all the plugins next in the chain and the original method call
-*
-* @link https://github.com/magento/magento2/issues/38934
-*/
+ * Performance workaround for issue https://github.com/magento/magento2/issues/38934
+ * Please note this around plugin doesn't call $proceed callable,
+ * and it will prevent the execution of all the plugins next in the chain and the original method call
+ *
+ * @link https://github.com/magento/magento2/issues/38934
+ */
 class SpecificOptionsPlugin
 {
     /**
@@ -68,7 +68,7 @@ class SpecificOptionsPlugin
      * @return array
      * @noinspection PhpMissingParamTypeInspection
      */
-    private function addEmptyOption(array $options, $emptyOption): array
+    private function addEmptyOption(array $options, array $emptyOption): array
     {
         array_unshift($options, $emptyOption);
         return $options;


### PR DESCRIPTION
| Q             | A
|---------------| ---
| Branch?       | 0.8 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| BC breaks?    | no
| Tests pass?   | no
| Tickets       | Ref HC-1705

Add missed types to params of private methods.  
Fixes phpstan error "has no value type specified in iterable type array"


<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained stable branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too). Lowest stable is `master` now.
 - Features and deprecations must be submitted against the latest branch. Latest is a branch for active development.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow (doc link will be added later)
 - Never break backward compatibility (see https://developerdocs.hawksearch.com/docs/magento-developers-bc-policy).
-->
