### PR TITLE
feat: drop min required version to PHP 8.1, Magento 2.4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Check out our [Getting Started](https://developerdocs.hawksearch.com/docs/magent
 
 ## Platform Version Support
 
-* Magento Open Source: 2.4.0 - 2.4.7
-* Adobe Commerce: 2.4.0 - 2.4.7
+* Magento Open Source: **2.4.4 - 2.4.7**
+* Adobe Commerce: **2.4.4 - 2.4.7**
 
 ## Installation Instructions
 

--- a/UPGRADE-0.8.md
+++ b/UPGRADE-0.8.md
@@ -1,5 +1,8 @@
 # UPGRADE FROM 0.7 to 0.8
 
+## Steps to action
+
+- Upgrade your Magento store at least to version 2.4.4 and PHP to version 8.1
 - Usage of protected property `Block\Adminhtml\System\Config\Product\CustomAttributes::columnRendererCache` is deprecated. Visibility will be changed to private in version 1.0.
 - Usage of protected property `Model\Indexer\Entities\ActionAbstract::eventManager` is deprecated. Visibility will be changed to private in version 1.0. Set via constructor injection.
 - Usage of protected property `Model\Indexer\Entities\ActionAbstract::messageManager` is deprecated. Visibility will be changed to private in version 1.0. Set via constructor injection.

--- a/UPGRADE-1.0.md
+++ b/UPGRADE-1.0.md
@@ -1,5 +1,7 @@
 # UPGRADE FROM 0.x to 1.0
 
+## Steps to action
+
 - Protected property `Block\Adminhtml\System\Config\Product\CustomAttributes::columnRendererCache` visibility has been changed to `private`.
 - Protected property `Model\Indexer\Entities\ActionAbstract::eventManager` visibility has been changed to `private`. Set via constructor injection.
 - Protected property `Model\Indexer\Entities\ActionAbstract::messageManager` visibility has been changed to `private`. Set via constructor injection.

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "type": "magento2-module",
     "version": "0.7.4",
     "require": {
-        "magento/framework": "^103.0",
-        "magento/module-asynchronous-operations": "~100.3",
+        "magento/framework": "^103.0.4",
+        "magento/module-asynchronous-operations": "^100.4.4",
         "hawksearch/connector": "^2.10",
         "ext-json": "*",
         "ext-PDO": "*",


### PR DESCRIPTION
| Q             | A
|---------------| ---
| Branch?       | 0.8 for features/bugs / master for hot fixes <!-- see below -->
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| BC breaks?    | yes/no (implicit BC for stores using older PHP and Magento framework)
| Tests pass?   | yes
| Tickets       | Fix HC-1711

We've started adding PHP type hints in the 0.8 release to all methods and properties. A new mixed type was added in PHP 8.0 which is used widely in HawkSarch classes. The other reason to drop off compatibility with PHP 7.4 is the fact that the minimum LTS Magento version is 2.4.4