### PR TITLE
chore: add PhpDoc return type annotations to public/protected methods

### DIFF
--- a/Api/Data/FacetBoostBuryInterface.php
+++ b/Api/Data/FacetBoostBuryInterface.php
@@ -39,7 +39,7 @@ interface FacetBoostBuryInterface
      * @param \HawkSearch\EsIndexing\Api\Data\FacetValueOrderInfoInterface[]|null $value
      * @return $this
      */
-    public function setBoostValues(?array $value): FacetBoostBuryInterface;
+    public function setBoostValues(?array $value): self;
 
     /**
      * @return \HawkSearch\EsIndexing\Api\Data\FacetValueOrderInfoInterface[]
@@ -50,6 +50,6 @@ interface FacetBoostBuryInterface
      * @param \HawkSearch\EsIndexing\Api\Data\FacetValueOrderInfoInterface[]|null $value
      * @return $this
      */
-    public function setBuryValues(?array $value): FacetBoostBuryInterface;
+    public function setBuryValues(?array $value): self;
 
 }

--- a/Api/Data/FacetInterface.php
+++ b/Api/Data/FacetInterface.php
@@ -81,7 +81,7 @@ interface FacetInterface
      * @param string|null $value
      * @return $this
      */
-    public function setSyncGuid(?string $value): FacetInterface;
+    public function setSyncGuid(?string $value): self;
 
     /**
      * @return int
@@ -91,7 +91,7 @@ interface FacetInterface
     /**
      * @return $this
      */
-    public function setFacetId(int $value): FacetInterface;
+    public function setFacetId(int $value): self;
 
     /**
      * @return string
@@ -102,7 +102,7 @@ interface FacetInterface
      * @param string|null $value
      * @return $this
      */
-    public function setName(?string $value): FacetInterface;
+    public function setName(?string $value): self;
 
     /**
      * @return string
@@ -113,7 +113,7 @@ interface FacetInterface
      * @param string|null $value
      * @return $this
      */
-    public function setFacetType(?string $value): FacetInterface;
+    public function setFacetType(?string $value): self;
 
     /**
      * @return string
@@ -124,7 +124,7 @@ interface FacetInterface
      * @param string|null $value
      * @return $this
      */
-    public function setFieldType(?string $value): FacetInterface;
+    public function setFieldType(?string $value): self;
 
     /**
      * @return int
@@ -134,7 +134,7 @@ interface FacetInterface
     /**
      * @return $this
      */
-    public function setMaxCount(int $value): FacetInterface;
+    public function setMaxCount(int $value): self;
 
     /**
      * @return int
@@ -144,7 +144,7 @@ interface FacetInterface
     /**
      * @return $this
      */
-    public function setMinHitCount(int $value): FacetInterface;
+    public function setMinHitCount(int $value): self;
 
     /**
      * @return string
@@ -155,7 +155,7 @@ interface FacetInterface
      * @param string|null $value
      * @return $this
      */
-    public function setField(?string $value): FacetInterface;
+    public function setField(?string $value): self;
 
     /**
      * @return string
@@ -166,7 +166,7 @@ interface FacetInterface
      * @param string|null $value
      * @return $this
      */
-    public function setParam(?string $value): FacetInterface;
+    public function setParam(?string $value): self;
 
     /**
      * @return string
@@ -177,7 +177,7 @@ interface FacetInterface
      * @param string|null $value
      * @return $this
      */
-    public function setDisplayType(?string $value): FacetInterface;
+    public function setDisplayType(?string $value): self;
 
     /**
      * @return int
@@ -187,7 +187,7 @@ interface FacetInterface
     /**
      * @return $this
      */
-    public function setScrollHeight(int $value): FacetInterface;
+    public function setScrollHeight(int $value): self;
 
     /**
      * @return int
@@ -197,7 +197,7 @@ interface FacetInterface
     /**
      * @return $this
      */
-    public function setScrollThreshold(int $value): FacetInterface;
+    public function setScrollThreshold(int $value): self;
 
     /**
      * @return int
@@ -207,7 +207,7 @@ interface FacetInterface
     /**
      * @return $this
      */
-    public function setTruncateThreshold(int $value): FacetInterface;
+    public function setTruncateThreshold(int $value): self;
 
     /**
      * @return int
@@ -217,7 +217,7 @@ interface FacetInterface
     /**
      * @return $this
      */
-    public function setSearchThreshold(int $value): FacetInterface;
+    public function setSearchThreshold(int $value): self;
 
     /**
      * @return int
@@ -227,7 +227,7 @@ interface FacetInterface
     /**
      * @return $this
      */
-    public function setSortOrder(int $value): FacetInterface;
+    public function setSortOrder(int $value): self;
 
     /**
      * @return bool
@@ -237,7 +237,7 @@ interface FacetInterface
     /**
      * @return $this
      */
-    public function setExpandSelection(bool $value): FacetInterface;
+    public function setExpandSelection(bool $value): self;
 
     /**
      * @return bool
@@ -247,7 +247,7 @@ interface FacetInterface
     /**
      * @return $this
      */
-    public function setIsCurrency(bool $value): FacetInterface;
+    public function setIsCurrency(bool $value): self;
 
     /**
      * @return bool
@@ -257,7 +257,7 @@ interface FacetInterface
     /**
      * @return $this
      */
-    public function setIsNumeric(bool $value): FacetInterface;
+    public function setIsNumeric(bool $value): self;
 
     /**
      * @return bool
@@ -267,7 +267,7 @@ interface FacetInterface
     /**
      * @return $this
      */
-    public function setIsSearch(bool $value): FacetInterface;
+    public function setIsSearch(bool $value): self;
 
     /**
      * @return bool
@@ -277,7 +277,7 @@ interface FacetInterface
     /**
      * @return $this
      */
-    public function setIsVisible(bool $value): FacetInterface;
+    public function setIsVisible(bool $value): self;
 
     /**
      * @return string
@@ -288,7 +288,7 @@ interface FacetInterface
      * @param string|null $value
      * @return $this
      */
-    public function setUBound(?string $value): FacetInterface;
+    public function setUBound(?string $value): self;
 
     /**
      * @return string
@@ -299,7 +299,7 @@ interface FacetInterface
      * @param string|null $value
      * @return $this
      */
-    public function setLBound(?string $value): FacetInterface;
+    public function setLBound(?string $value): self;
 
     /**
      * @return string
@@ -310,7 +310,7 @@ interface FacetInterface
      * @param string|null $value
      * @return $this
      */
-    public function setIncrement(?string $value): FacetInterface;
+    public function setIncrement(?string $value): self;
 
     /**
      * @return int
@@ -320,7 +320,7 @@ interface FacetInterface
     /**
      * @return $this
      */
-    public function setNofVisible(int $value): FacetInterface;
+    public function setNofVisible(int $value): self;
 
     /**
      * @return int
@@ -330,7 +330,7 @@ interface FacetInterface
     /**
      * @return $this
      */
-    public function setHeight(int $value): FacetInterface;
+    public function setHeight(int $value): self;
 
     /**
      * @return string
@@ -341,7 +341,7 @@ interface FacetInterface
      * @param string|null $value
      * @return $this
      */
-    public function setDisplayRuleXML(?string $value): FacetInterface;
+    public function setDisplayRuleXML(?string $value): self;
 
     /**
      * @return string
@@ -352,7 +352,7 @@ interface FacetInterface
      * @param string|null $value
      * @return $this
      */
-    public function setSortBy(?string $value): FacetInterface;
+    public function setSortBy(?string $value): self;
 
     /**
      * @return int
@@ -362,7 +362,7 @@ interface FacetInterface
     /**
      * @return $this
      */
-    public function setParentId(int $value): FacetInterface;
+    public function setParentId(int $value): self;
 
     /**
      * @return bool
@@ -372,7 +372,7 @@ interface FacetInterface
     /**
      * @return $this
      */
-    public function setIsCollapsible(bool $value): FacetInterface;
+    public function setIsCollapsible(bool $value): self;
 
     /**
      * @return bool
@@ -382,7 +382,7 @@ interface FacetInterface
     /**
      * @return $this
      */
-    public function setIsCollapsedDefault(bool $value): FacetInterface;
+    public function setIsCollapsedDefault(bool $value): self;
 
     /**
      * @return string
@@ -393,7 +393,7 @@ interface FacetInterface
      * @param string|null $value
      * @return $this
      */
-    public function setSwatchData(?string $value): FacetInterface;
+    public function setSwatchData(?string $value): self;
 
     /**
      * @return int
@@ -403,7 +403,7 @@ interface FacetInterface
     /**
      * @return $this
      */
-    public function setFacetRangeDisplayType(int $value): FacetInterface;
+    public function setFacetRangeDisplayType(int $value): self;
 
     /**
      * @return bool
@@ -413,7 +413,7 @@ interface FacetInterface
     /**
      * @return $this
      */
-    public function setPreloadChildren(bool $value): FacetInterface;
+    public function setPreloadChildren(bool $value): self;
 
     /**
      * @return string
@@ -424,7 +424,7 @@ interface FacetInterface
      * @param string|null $value
      * @return $this
      */
-    public function setTooltip(?string $value): FacetInterface;
+    public function setTooltip(?string $value): self;
 
     /**
      * @return bool
@@ -434,7 +434,7 @@ interface FacetInterface
     /**
      * @return $this
      */
-    public function setShowSliderInputs(bool $value): FacetInterface;
+    public function setShowSliderInputs(bool $value): self;
 
     /**
      * @return bool
@@ -444,7 +444,7 @@ interface FacetInterface
     /**
      * @return $this
      */
-    public function setShowFacetImageCount(bool $value): FacetInterface;
+    public function setShowFacetImageCount(bool $value): self;
 
     /**
      * @return \HawkSearch\EsIndexing\Api\Data\FacetRangeModelInterface[]
@@ -455,7 +455,7 @@ interface FacetInterface
      * @param \HawkSearch\EsIndexing\Api\Data\FacetRangeModelInterface[]|null $value
      * @return $this
      */
-    public function setFacetRanges(?array $value): FacetInterface;
+    public function setFacetRanges(?array $value): self;
 
     /**
      * @return string
@@ -466,7 +466,7 @@ interface FacetInterface
      * @param string|null $value
      * @return $this
      */
-    public function setTags(?string $value): FacetInterface;
+    public function setTags(?string $value): self;
 
     /**
      * @return string
@@ -477,7 +477,7 @@ interface FacetInterface
      * @param string|null $value
      * @return $this
      */
-    public function setCreateDate(?string $value): FacetInterface;
+    public function setCreateDate(?string $value): self;
 
     /**
      * @return string
@@ -488,7 +488,7 @@ interface FacetInterface
      * @param string|null $value
      * @return $this
      */
-    public function setModifyDate(?string $value): FacetInterface;
+    public function setModifyDate(?string $value): self;
 
     /**
      * @return \HawkSearch\EsIndexing\Api\Data\FacetBoostBuryInterface
@@ -499,7 +499,7 @@ interface FacetInterface
      * @param \HawkSearch\EsIndexing\Api\Data\FacetBoostBuryInterface|null $value
      * @return $this
      */
-    public function setBoostBury(?FacetBoostBuryInterface $value): FacetInterface;
+    public function setBoostBury(?FacetBoostBuryInterface $value): self;
 
     /**
      * @return string
@@ -510,7 +510,7 @@ interface FacetInterface
      * @param string|null $value
      * @return $this
      */
-    public function setListName(?string $value): FacetInterface;
+    public function setListName(?string $value): self;
 
     /**
      * @return int
@@ -520,7 +520,7 @@ interface FacetInterface
     /**
      * @return $this
      */
-    public function setNumericPrecision(int $value): FacetInterface;
+    public function setNumericPrecision(int $value): self;
 
     /**
      * @return string
@@ -531,7 +531,7 @@ interface FacetInterface
      * @param string|null $value
      * @return $this
      */
-    public function setCurrencySymbol(?string $value): FacetInterface;
+    public function setCurrencySymbol(?string $value): self;
 
     /**
      * @return string
@@ -542,5 +542,5 @@ interface FacetInterface
      * @param string|null $value
      * @return $this
      */
-    public function setDefaultItemType(?string $value): FacetInterface;
+    public function setDefaultItemType(?string $value): self;
 }

--- a/Api/Data/FacetRangeModelInterface.php
+++ b/Api/Data/FacetRangeModelInterface.php
@@ -43,7 +43,7 @@ interface FacetRangeModelInterface
     /**
      * @return $this
      */
-    public function setRangeId(int $value): FacetRangeModelInterface;
+    public function setRangeId(int $value): self;
 
     /**
      * @return string
@@ -54,7 +54,7 @@ interface FacetRangeModelInterface
      * @param string|null $value
      * @return $this
      */
-    public function setName(?string $value): FacetRangeModelInterface;
+    public function setName(?string $value): self;
 
     /**
      * @return string
@@ -65,7 +65,7 @@ interface FacetRangeModelInterface
      * @param string|null $value
      * @return $this
      */
-    public function setLBound(?string $value): FacetRangeModelInterface;
+    public function setLBound(?string $value): self;
 
     /**
      * @return string
@@ -76,7 +76,7 @@ interface FacetRangeModelInterface
      * @param string|null $value
      * @return $this
      */
-    public function setUBound(?string $value): FacetRangeModelInterface;
+    public function setUBound(?string $value): self;
 
     /**
      * @return int
@@ -86,7 +86,7 @@ interface FacetRangeModelInterface
     /**
      * @return $this
      */
-    public function setSortOrder(int $value): FacetRangeModelInterface;
+    public function setSortOrder(int $value): self;
 
     /**
      * @return string
@@ -97,7 +97,7 @@ interface FacetRangeModelInterface
      * @param string|null $value
      * @return $this
      */
-    public function setAssetName(?string $value): FacetRangeModelInterface;
+    public function setAssetName(?string $value): self;
 
     /**
      * @return string
@@ -108,5 +108,5 @@ interface FacetRangeModelInterface
      * @param string|null $value
      * @return $this
      */
-    public function setAssetUrl(?string $value): FacetRangeModelInterface;
+    public function setAssetUrl(?string $value): self;
 }

--- a/Api/Data/FacetValueOrderInfoInterface.php
+++ b/Api/Data/FacetValueOrderInfoInterface.php
@@ -39,7 +39,7 @@ interface FacetValueOrderInfoInterface
      * @param string|null $value
      * @return $this
      */
-    public function setValue(?string $value): FacetValueOrderInfoInterface;
+    public function setValue(?string $value): self;
 
     /**
      * @return int
@@ -49,5 +49,5 @@ interface FacetValueOrderInfoInterface
     /**
      * @return $this
      */
-    public function setSortOrder(int $value): FacetValueOrderInfoInterface;
+    public function setSortOrder(int $value): self;
 }

--- a/Api/Data/FieldInterface.php
+++ b/Api/Data/FieldInterface.php
@@ -82,7 +82,7 @@ interface FieldInterface
     /**
      * @return $this
      */
-    public function setFieldId(int $value): FieldInterface;
+    public function setFieldId(int $value): self;
 
     /**
      * @return string
@@ -93,7 +93,7 @@ interface FieldInterface
      * @param string|null $value
      * @return $this
      */
-    public function setSyncGuid(?string $value): FieldInterface;
+    public function setSyncGuid(?string $value): self;
 
     /**
      * @return string
@@ -104,7 +104,7 @@ interface FieldInterface
      * @param string|null $value
      * @return $this
      */
-    public function setLabel(?string $value): FieldInterface;
+    public function setLabel(?string $value): self;
 
     /**
      * @return string
@@ -115,7 +115,7 @@ interface FieldInterface
      * @param string|null $value
      * @return $this
      */
-    public function setName(?string $value): FieldInterface;
+    public function setName(?string $value): self;
 
     /**
      * @return bool
@@ -125,7 +125,7 @@ interface FieldInterface
     /**
      * @return $this
      */
-    public function setIsPrimaryKey(bool $value): FieldInterface;
+    public function setIsPrimaryKey(bool $value): self;
 
     /**
      * @return string
@@ -136,7 +136,7 @@ interface FieldInterface
      * @param string|null $value
      * @return $this
      */
-    public function setType(?string $value): FieldInterface;
+    public function setType(?string $value): self;
 
     /**
      * @return string
@@ -147,7 +147,7 @@ interface FieldInterface
      * @param string|null $value
      * @return $this
      */
-    public function setFieldType(?string $value): FieldInterface;
+    public function setFieldType(?string $value): self;
 
     /**
      * @return int
@@ -157,7 +157,7 @@ interface FieldInterface
     /**
      * @return $this
      */
-    public function setBoost(int $value): FieldInterface;
+    public function setBoost(int $value): self;
 
     /**
      * @return int
@@ -167,7 +167,7 @@ interface FieldInterface
     /**
      * @return $this
      */
-    public function setFacetHandler(int $value): FieldInterface;
+    public function setFacetHandler(int $value): self;
 
     /**
      * @return bool
@@ -177,7 +177,7 @@ interface FieldInterface
     /**
      * @return $this
      */
-    public function setIsOutput(bool $value): FieldInterface;
+    public function setIsOutput(bool $value): self;
 
     /**
      * @return bool
@@ -187,7 +187,7 @@ interface FieldInterface
     /**
      * @return $this
      */
-    public function setIsShingle(bool $value): FieldInterface;
+    public function setIsShingle(bool $value): self;
 
     /**
      * @return bool
@@ -197,7 +197,7 @@ interface FieldInterface
     /**
      * @return $this
      */
-    public function setIsBestFragment(bool $value): FieldInterface;
+    public function setIsBestFragment(bool $value): self;
 
     /**
      * @return bool
@@ -207,7 +207,7 @@ interface FieldInterface
     /**
      * @return $this
      */
-    public function setIsDictionary(bool $value): FieldInterface;
+    public function setIsDictionary(bool $value): self;
 
     /**
      * @return bool
@@ -217,7 +217,7 @@ interface FieldInterface
     /**
      * @return $this
      */
-    public function setIsSort(bool $value): FieldInterface;
+    public function setIsSort(bool $value): self;
 
     /**
      * @return bool
@@ -227,7 +227,7 @@ interface FieldInterface
     /**
      * @return $this
      */
-    public function setIsPrefix(bool $value): FieldInterface;
+    public function setIsPrefix(bool $value): self;
 
     /**
      * @return bool
@@ -237,7 +237,7 @@ interface FieldInterface
     /**
      * @return $this
      */
-    public function setIsHidden(bool $value): FieldInterface;
+    public function setIsHidden(bool $value): self;
 
     /**
      * @return bool
@@ -247,7 +247,7 @@ interface FieldInterface
     /**
      * @return $this
      */
-    public function setIsCompare(bool $value): FieldInterface;
+    public function setIsCompare(bool $value): self;
 
     /**
      * @return int
@@ -257,7 +257,7 @@ interface FieldInterface
     /**
      * @return $this
      */
-    public function setSortOrder(int $value): FieldInterface;
+    public function setSortOrder(int $value): self;
 
     /**
      * @return string
@@ -268,7 +268,7 @@ interface FieldInterface
      * @param string|null $value
      * @return $this
      */
-    public function setPartialQuery(?string $value): FieldInterface;
+    public function setPartialQuery(?string $value): self;
 
     /**
      * @return bool
@@ -278,7 +278,7 @@ interface FieldInterface
     /**
      * @return $this
      */
-    public function setIsKeywordText(bool $value): FieldInterface;
+    public function setIsKeywordText(bool $value): self;
 
     /**
      * @return bool
@@ -288,7 +288,7 @@ interface FieldInterface
     /**
      * @return $this
      */
-    public function setIsQuery(bool $value): FieldInterface;
+    public function setIsQuery(bool $value): self;
 
     /**
      * @return bool
@@ -298,7 +298,7 @@ interface FieldInterface
     /**
      * @return $this
      */
-    public function setIsQueryText(bool $value): FieldInterface;
+    public function setIsQueryText(bool $value): self;
 
     /**
      * @return bool
@@ -308,7 +308,7 @@ interface FieldInterface
     /**
      * @return $this
      */
-    public function setSkipCustom(bool $value): FieldInterface;
+    public function setSkipCustom(bool $value): self;
 
     /**
      * @return bool
@@ -318,7 +318,7 @@ interface FieldInterface
     /**
      * @return $this
      */
-    public function setStripHtml(bool $value): FieldInterface;
+    public function setStripHtml(bool $value): self;
 
     /**
      * @return int
@@ -328,7 +328,7 @@ interface FieldInterface
     /**
      * @return $this
      */
-    public function setMinNGramAnalyzer(int $value): FieldInterface;
+    public function setMinNGramAnalyzer(int $value): self;
 
     /**
      * @return int
@@ -338,7 +338,7 @@ interface FieldInterface
     /**
      * @return $this
      */
-    public function setMaxNGramAnalyzer(int $value): FieldInterface;
+    public function setMaxNGramAnalyzer(int $value): self;
 
     /**
      * @return int
@@ -348,7 +348,7 @@ interface FieldInterface
     /**
      * @return $this
      */
-    public function setCoordinateType(int $value): FieldInterface;
+    public function setCoordinateType(int $value): self;
 
     /**
      * @return bool
@@ -358,7 +358,7 @@ interface FieldInterface
     /**
      * @return $this
      */
-    public function setOmitNorms(bool $value): FieldInterface;
+    public function setOmitNorms(bool $value): self;
 
     /**
      * @return string
@@ -369,7 +369,7 @@ interface FieldInterface
      * @param string|null $value
      * @return $this
      */
-    public function setItemMapping(?string $value): FieldInterface;
+    public function setItemMapping(?string $value): self;
 
     /**
      * @return string
@@ -380,7 +380,7 @@ interface FieldInterface
      * @param string|null $value
      * @return $this
      */
-    public function setDefaultValue(?string $value): FieldInterface;
+    public function setDefaultValue(?string $value): self;
 
     /**
      * @return bool
@@ -390,7 +390,7 @@ interface FieldInterface
     /**
      * @return $this
      */
-    public function setUseForPrediction(bool $value): FieldInterface;
+    public function setUseForPrediction(bool $value): self;
 
     /**
      * @return string
@@ -401,7 +401,7 @@ interface FieldInterface
      * @param string|null $value
      * @return $this
      */
-    public function setCopyTo(?string $value): FieldInterface;
+    public function setCopyTo(?string $value): self;
 
     /**
      * @return string
@@ -412,7 +412,7 @@ interface FieldInterface
      * @param string|null $value
      * @return $this
      */
-    public function setAnalyzer(?string $value): FieldInterface;
+    public function setAnalyzer(?string $value): self;
 
     /**
      * @return bool
@@ -422,7 +422,7 @@ interface FieldInterface
     /**
      * @return $this
      */
-    public function setDoNotStore(bool $value): FieldInterface;
+    public function setDoNotStore(bool $value): self;
 
     /**
      * @return string
@@ -433,7 +433,7 @@ interface FieldInterface
      * @param string|null $value
      * @return $this
      */
-    public function setTags(?string $value): FieldInterface;
+    public function setTags(?string $value): self;
 
     /**
      * @return int[]
@@ -444,7 +444,7 @@ interface FieldInterface
      * @param int[]|null $value
      * @return $this
      */
-    public function setIterations(?array $value): FieldInterface;
+    public function setIterations(?array $value): self;
 
     /**
      * @return string
@@ -455,7 +455,7 @@ interface FieldInterface
      * @param string|null $value
      * @return $this
      */
-    public function setAnalyzerLanguage(?string $value): FieldInterface;
+    public function setAnalyzerLanguage(?string $value): self;
 
     /**
      * @return string
@@ -466,7 +466,7 @@ interface FieldInterface
      * @param string|null $value
      * @return $this
      */
-    public function setPreviewMapping(?string $value): FieldInterface;
+    public function setPreviewMapping(?string $value): self;
 
     /**
      * @return bool
@@ -476,7 +476,7 @@ interface FieldInterface
     /**
      * @return $this
      */
-    public function setOmitTfAndPos(bool $value): FieldInterface;
+    public function setOmitTfAndPos(bool $value): self;
 
     /**
      * @return string
@@ -487,7 +487,7 @@ interface FieldInterface
      * @param string|null $value
      * @return $this
      */
-    public function setCreateDate(?string $value): FieldInterface;
+    public function setCreateDate(?string $value): self;
 
     /**
      * @return string
@@ -498,7 +498,7 @@ interface FieldInterface
      * @param string|null $value
      * @return $this
      */
-    public function setModifyDate(?string $value): FieldInterface;
+    public function setModifyDate(?string $value): self;
 
     /**
      * @return bool
@@ -508,7 +508,7 @@ interface FieldInterface
     /**
      * @return $this
      */
-    public function setIsChild(bool $value): FieldInterface;
+    public function setIsChild(bool $value): self;
 
     /**
      * @return bool
@@ -518,5 +518,5 @@ interface FieldInterface
     /**
      * @return $this
      */
-    public function setIsHierarchical(bool $value): FieldInterface;
+    public function setIsHierarchical(bool $value): self;
 }

--- a/Api/IndexManagementInterface.php
+++ b/Api/IndexManagementInterface.php
@@ -38,10 +38,8 @@ interface IndexManagementInterface
      * Get active index for indexing
      * Use current index for partial delta index updates
      * Current index is used for searching
-     *
-     * @return string
      */
-    public function getIndexName(bool $useCurrent = false) : ?string;
+    public function getIndexName(bool $useCurrent = false): ?string;
 
     /**
      * @return void

--- a/Block/Adminhtml/Bulk/Details/RetryButton.php
+++ b/Block/Adminhtml/Bulk/Details/RetryButton.php
@@ -30,12 +30,14 @@ class RetryButton implements ButtonProviderInterface
     public function __construct(
         Details $details,
         RequestInterface $request
-    )
-    {
+    ) {
         $this->details = $details;
         $this->request = $request;
     }
 
+    /**
+     * @return array
+     */
     public function getButtonData()
     {
         $uuid = $this->request->getParam('uuid');

--- a/Block/Adminhtml/System/Config/Product/CustomAttributes.php
+++ b/Block/Adminhtml/System/Config/Product/CustomAttributes.php
@@ -70,8 +70,7 @@ class CustomAttributes extends AbstractFieldArray
         HawksearchFields $hawksearchFields,
         ProductAttributes $productAttributes,
         array $data = []
-    )
-    {
+    ) {
         $this->hawksearchFields = $hawksearchFields;
         $this->productAttributes = $productAttributes;
         parent::__construct($context, $data);
@@ -116,6 +115,7 @@ class CustomAttributes extends AbstractFieldArray
      * @param string $name
      * @param array<string, mixed> $params
      * @return void
+     * @throws LocalizedException
      */
     public function addColumn($name, $params)
     {
@@ -219,6 +219,10 @@ class CustomAttributes extends AbstractFieldArray
         return $renderer;
     }
 
+    /**
+     * @return string
+     * @throws LocalizedException
+     */
     protected function _getElementHtml(AbstractElement $element)
     {
         $html = parent::_getElementHtml($element);

--- a/Block/Html/Head/JsConfig.php
+++ b/Block/Html/Head/JsConfig.php
@@ -37,13 +37,15 @@ class JsConfig extends Template
         LayoutConfigProcessorInterface $configProcessor,
         array $data = []
 
-    )
-    {
+    ) {
         $this->configProcessor = $configProcessor;
         $this->serializer = $serializer;
         parent::__construct($context, $data);
     }
 
+    /**
+     * @return string
+     */
     public function getJsLayout()
     {
         return $this->serializer->serialize($this->configProcessor->process($this->jsLayout ?? []));

--- a/Block/Tracking.php
+++ b/Block/Tracking.php
@@ -49,8 +49,7 @@ class Tracking extends Template
         EventTrackingConfig $eventTrackingConfig,
         array $data = [],
         ?SerializerInterface $serializer = null
-    )
-    {
+    ) {
         $this->orderCollectionFactory = $orderCollectionFactory;
         $this->productEntityType = $productEntityType;
         $this->eventTrackingConfig = $eventTrackingConfig;
@@ -68,6 +67,9 @@ class Tracking extends Template
         return $this->eventTrackingConfig->isEnabled();
     }
 
+    /**
+     * @return string
+     */
     protected function _toHtml()
     {
         if (!$this->isAvailable()) {

--- a/Console/Command/RetryBulk.php
+++ b/Console/Command/RetryBulk.php
@@ -54,8 +54,7 @@ class RetryBulk extends Command
         BulkSummaryInterfaceFactory $bulkSummaryFactory,
         EntityManager $entityManager,
         string $name = null
-    )
-    {
+    ) {
         parent::__construct($name);
         $this->bulkManagement = $bulkManagement;
         $this->bulkStatus = $bulkStatus;
@@ -79,6 +78,9 @@ class RetryBulk extends Command
         parent::configure();
     }
 
+    /**
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $bulkUuid = $input->getArgument(self::INPUT_BULK_UUID);

--- a/Controller/Adminhtml/Bulkoperations/Details.php
+++ b/Controller/Adminhtml/Bulkoperations/Details.php
@@ -39,8 +39,7 @@ class Details extends Action implements HttpGetActionInterface
         PageFactory $resultPageFactory,
         BulkAccessValidator $bulkAccessValidator,
         string $menuId = 'HawkSearch_EsIndexing::bulk_operations'
-    )
-    {
+    ) {
         $this->resultPageFactory = $resultPageFactory;
         $this->bulkAccessValidator = $bulkAccessValidator;
         $this->menuId = $menuId;
@@ -48,7 +47,7 @@ class Details extends Action implements HttpGetActionInterface
     }
 
     /**
-     * @noinspection PhpMissingReturnTypeInspection
+     * @return bool
      */
     protected function _isAllowed()
     {
@@ -59,7 +58,6 @@ class Details extends Action implements HttpGetActionInterface
      * Bulk list action
      *
      * @return Page
-     * @noinspection PhpMissingReturnTypeInspection
      */
     public function execute()
     {

--- a/Controller/Adminhtml/Bulkoperations/Index.php
+++ b/Controller/Adminhtml/Bulkoperations/Index.php
@@ -17,6 +17,7 @@ namespace HawkSearch\EsIndexing\Controller\Adminhtml\Bulkoperations;
 use Magento\Backend\App\Action;
 use Magento\Backend\App\Action\Context;
 use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\View\Result\Page;
 use Magento\Framework\View\Result\PageFactory;
 
 class Index extends Action implements HttpGetActionInterface
@@ -35,8 +36,7 @@ class Index extends Action implements HttpGetActionInterface
         Context $context,
         PageFactory $resultPageFactory,
         string $menuId = 'HawkSearch_EsIndexing::bulk_operations'
-    )
-    {
+    ) {
         $this->resultPageFactory = $resultPageFactory;
         $this->menuId = $menuId;
         parent::__construct($context);
@@ -45,7 +45,7 @@ class Index extends Action implements HttpGetActionInterface
     /**
      * Bulk list action
      *
-     * @return \Magento\Framework\View\Result\Page
+     * @return Page
      */
     public function execute()
     {

--- a/Controller/Adminhtml/Bulkoperations/Retry.php
+++ b/Controller/Adminhtml/Bulkoperations/Retry.php
@@ -24,6 +24,7 @@ use Magento\Backend\Model\View\Result\Redirect;
 use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Framework\Bulk\BulkManagementInterface;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Controller\ResultInterface;
 use Magento\Framework\DataObject\Factory as DataObjectFactory;
 use Magento\Framework\EntityManager\EntityManager;
 use Magento\Framework\Exception\NoSuchEntityException;
@@ -67,8 +68,7 @@ class Retry extends Action implements HttpPostActionInterface
         EntityManager $entityManager,
         BulkStatusInterface $bulkStatus,
         DataObjectFactory $dataObjectFactory
-    )
-    {
+    ) {
         parent::__construct($context);
         $this->bulkManagement = $bulkManagement;
         $this->notificationManagement = $notificationManagement;
@@ -79,11 +79,17 @@ class Retry extends Action implements HttpPostActionInterface
         $this->dataObjectFactory = $dataObjectFactory;
     }
 
+    /**
+     * @return bool
+     */
     protected function _isAllowed()
     {
         return parent::_isAllowed() && $this->bulkAccessValidator->isAllowed($this->getRequest()->getParam('uuid'));
     }
 
+    /**
+     * @return ResultInterface
+     */
     public function execute()
     {
         $bulkUuid = $this->getRequest()->getParam('uuid');

--- a/Gateway/Request/LandingPageListBuilder.php
+++ b/Gateway/Request/LandingPageListBuilder.php
@@ -15,15 +15,20 @@ declare(strict_types=1);
 namespace HawkSearch\EsIndexing\Gateway\Request;
 
 use HawkSearch\Connector\Gateway\InstructionException;
+use HawkSearch\Connector\Gateway\InstructionInterface;
 use HawkSearch\Connector\Gateway\Request\BuilderInterface;
 use HawkSearch\EsIndexing\Api\Data\LandingPageInterface;
 use HawkSearch\EsIndexing\Model\LandingPage;
 
+/**
+ * @phpstan-import-type RequestSubject from InstructionInterface
+ */
 class LandingPageListBuilder implements BuilderInterface
 {
     /**
      * Build request with Landing Pages collection
      *
+     * @return RequestSubject
      * @throws InstructionException
      */
     public function build(array $buildSubject)

--- a/Helper/ObjectHelper.php
+++ b/Helper/ObjectHelper.php
@@ -38,8 +38,7 @@ class ObjectHelper
         FilterFactory $filterFactory,
         SortOrderFactory $sortOrderFactory,
         FilterGroupBuilder $filterGroupBuilder
-    )
-    {
+    ) {
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;
         $this->filterFactory = $filterFactory;
         $this->sortOrderFactory = $sortOrderFactory;
@@ -47,12 +46,16 @@ class ObjectHelper
     }
 
     /**
+     * @phpstan-type keyFilterGroups SearchCriteria::FILTER_GROUPS
+     * @phpstan-type keySortOrders SearchCriteria::SORT_ORDERS
+     * @phpstan-type keyPageSize SearchCriteria::PAGE_SIZE
+     * @phpstan-type keyCurrentPage SearchCriteria::CURRENT_PAGE
      * @param array{
-     *     "SearchCriteria::FILTER_GROUPS":array<mixed>,
-     *     "SearchCriteria::SORT_ORDERS":array<mixed>,
-     *     "SearchCriteria::PAGE_SIZE":?int,
-     *     "SearchCriteria::CURRENT_PAGE":?int,
-     * } $data
+     *              keyFilterGroups: array<mixed>,
+     *              keySortOrders: array<mixed>,
+     *              keyPageSize: ?int,
+     *              keyCurrentPage: ?int,
+     *        } $data
      * @return SearchCriteria
      */
     public function convertArrayToSearchCriteriaObject(array $data)

--- a/Helper/PricingHelper.php
+++ b/Helper/PricingHelper.php
@@ -35,8 +35,7 @@ class PricingHelper extends AbstractHelper
         TaxHelper $taxHelper,
         CatalogHelper $catalogHelper,
         Context $context
-    )
-    {
+    ) {
         parent::__construct($context);
         $this->taxHelper = $taxHelper;
         $this->catalogHelper = $catalogHelper;
@@ -53,17 +52,13 @@ class PricingHelper extends AbstractHelper
     /**
      * @param string|int|Store $store
      * @param bool $force
-     * @return bool
      * @noinspection PhpMissingParamTypeInspection
      */
     public function isIncludeTax($store, bool $force = false): bool
     {
         return $force || $this->taxHelper->getPriceDisplayType($store) == TaxConfig::DISPLAY_TYPE_INCLUDING_TAX;
     }
-
-    /**
-     * @return float
-     */
+    
     public function handleTax(ProductModel $product, float $price, bool $forceIncludeTax = false): float
     {
         $store = $product->getStore();

--- a/Model/Api/SearchCriteria/JoinProcessor/CleanAttributes.php
+++ b/Model/Api/SearchCriteria/JoinProcessor/CleanAttributes.php
@@ -26,9 +26,11 @@ class CleanAttributes implements CustomJoinInterface
 {
     /**
      * @param AbstractCollection $collection
+     * @return bool
      */
     public function apply(AbstractDb $collection)
     {
         $collection->removeAttributeToSelect();
+        return true;
     }
 }

--- a/Model/Api/SearchCriteria/JoinProcessor/ProductMainAttributes.php
+++ b/Model/Api/SearchCriteria/JoinProcessor/ProductMainAttributes.php
@@ -34,10 +34,13 @@ class ProductMainAttributes implements CustomJoinInterface
 
     /**
      * @param ProductCollection $collection
+     * @return bool
      */
     public function apply(AbstractDb $collection)
     {
         $collection->removeAttributeToSelect();
         $collection->addAttributeToSelect($this->attributes->getIndexedAttributes());
+
+        return true;
     }
 }

--- a/Model/Api/SearchCriteria/JoinProcessor/ProductPrices.php
+++ b/Model/Api/SearchCriteria/JoinProcessor/ProductPrices.php
@@ -24,9 +24,12 @@ class ProductPrices implements CustomJoinInterface
 
     /**
      * @param ProductCollection $collection
+     * @return bool
      */
     public function apply(AbstractDb $collection)
     {
         $collection->addPriceData();
+
+        return true;
     }
 }

--- a/Model/Api/SearchCriteria/JoinProcessor/ReviewRatingSummary.php
+++ b/Model/Api/SearchCriteria/JoinProcessor/ReviewRatingSummary.php
@@ -33,8 +33,7 @@ class ReviewRatingSummary implements CustomJoinInterface
         SummaryFactory $sumResourceFactory,
         StoreManagerInterface $storeManager,
         ProductMetadataInterface $productMetadata
-    )
-    {
+    ) {
         $this->sumResourceFactory = $sumResourceFactory;
         $this->storeManager = $storeManager;
         $this->productMetadata = $productMetadata;
@@ -42,6 +41,7 @@ class ReviewRatingSummary implements CustomJoinInterface
 
     /**
      * @param ProductCollection $collection
+     * @return bool
      * @throws LocalizedException
      */
     public function apply(AbstractDb $collection)
@@ -63,5 +63,7 @@ class ReviewRatingSummary implements CustomJoinInterface
                 \Magento\Review\Model\Review::ENTITY_PRODUCT_CODE
             );
         }
+
+        return true;
     }
 }

--- a/Model/Api/SearchCriteria/JoinProcessor/SkipCategoryIds.php
+++ b/Model/Api/SearchCriteria/JoinProcessor/SkipCategoryIds.php
@@ -26,9 +26,12 @@ class SkipCategoryIds implements CustomJoinInterface
 {
     /**
      * @param AbstractCollection $collection
+     * @return bool
      */
     public function apply(AbstractDb $collection)
     {
         $collection->setFlag('category_ids_added', true);
+
+        return true;
     }
 }

--- a/Model/Api/SearchCriteria/JoinProcessor/UrlRewrites.php
+++ b/Model/Api/SearchCriteria/JoinProcessor/UrlRewrites.php
@@ -24,9 +24,12 @@ class UrlRewrites implements CustomJoinInterface
 
     /**
      * @param ProductCollection $collection
+     * @return bool
      */
     public function apply(AbstractDb $collection)
     {
         $collection->addUrlRewrite();
+
+        return true;
     }
 }

--- a/Model/BulkOperation/Options.php
+++ b/Model/BulkOperation/Options.php
@@ -21,6 +21,9 @@ use Magento\Framework\Data\OptionSourceInterface;
  */
 class Options implements OptionSourceInterface
 {
+    /**
+     * @return list<array{label: \Stringable, value: int}>
+     */
     public function toOptionArray()
     {
         return [

--- a/Model/Config/Source/HawksearchFields.php
+++ b/Model/Config/Source/HawksearchFields.php
@@ -35,6 +35,7 @@ class HawksearchFields implements OptionSourceInterface
 
     /**
      * @noinspection PhpMissingReturnTypeInspection
+     * @return list<array{label: \Stringable, value: ?string}>
      */
     public function toOptionArray()
     {
@@ -42,12 +43,12 @@ class HawksearchFields implements OptionSourceInterface
         foreach ($this->getFields() as $field) {
             $options[] = [
                 'value' => $field->getName(),
-                'label' => $field->getName()
+                'label' => $field->getName(),
             ];
         }
         array_unshift($options, [
             'value' => null,
-            'label' => '--Please Select--'
+            'label' => __('--Please Select--'),
         ]);
 
         return $options;

--- a/Model/Config/Source/ProductAttributes.php
+++ b/Model/Config/Source/ProductAttributes.php
@@ -23,12 +23,12 @@ class ProductAttributes implements OptionSourceInterface
 
     public function __construct(
         Attributes $attributes
-    )
-    {
+    ) {
         $this->attributes = $attributes;
     }
 
     /**
+     * @return list<array{label: \Stringable, value: ?string}>
      * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function toOptionArray()
@@ -44,7 +44,7 @@ class ProductAttributes implements OptionSourceInterface
         foreach ($allAttributes as $code => $label) {
             $options[] = [
                 'value' => $code,
-                'label' => $code ? $code : $label,
+                'label' => $code ?: $label,
             ];
         }
 

--- a/Model/ContentPage/Field/Handler/Url.php
+++ b/Model/ContentPage/Field/Handler/Url.php
@@ -29,12 +29,13 @@ class Url implements FieldHandlerInterface
     private StoreManagerInterface $storeManager;
 
     public function __construct(
-        StoreManagerInterface $storeManager)
-    {
+        StoreManagerInterface $storeManager
+    ) {
         $this->storeManager = $storeManager;
     }
 
     /**
+     * @return string
      * @throws NoSuchEntityException
      */
     public function handle(DataObject $item, string $fieldName)

--- a/Model/Cron/RetryFailedOperations.php
+++ b/Model/Cron/RetryFailedOperations.php
@@ -69,8 +69,7 @@ class RetryFailedOperations
         FailureRecoveryConfig $failureRecoveryConfig,
         int $errorCode = self::ERROR_CODE
 
-    )
-    {
+    ) {
         $this->bulkOperationManagement = $bulkOperationManagement;
         $this->messageEncoder = $messageEncoder;
         $this->messageValidator = $messageValidator;
@@ -90,7 +89,6 @@ class RetryFailedOperations
      * Automatically retry failed and not started operations.
      * When trials limit is reached then operation is rejected and can be recovered manually
      *
-     * @return void
      * @throws LocalizedException
      */
     public function execute(): void
@@ -211,7 +209,6 @@ class RetryFailedOperations
     }
 
     /**
-     * @return bool
      * @throws LocalizedException
      */
     protected function retryOperation(OperationInterface $operation): bool
@@ -243,8 +240,6 @@ class RetryFailedOperations
 
     /**
      * Get number of retry attempts for operation
-     *
-     * @return int
      */
     protected function getOperationTrials(QueueOperationDataInterface $operation): int
     {
@@ -255,8 +250,6 @@ class RetryFailedOperations
 
     /**
      * Increase number of retry attempts for operation
-     *
-     * @return QueueOperationDataInterface
      */
     protected function increaseOperationTrials(QueueOperationDataInterface $operationData): QueueOperationDataInterface
     {
@@ -272,10 +265,12 @@ class RetryFailedOperations
      * @param OperationInterface $operation
      * @param int|null $errorCode
      * @param string|null $message
-     * @return bool
      */
-    protected function rejectOperation(OperationInterface $operation, int $errorCode = null, string $message = null): bool
-    {
+    protected function rejectOperation(
+        OperationInterface $operation,
+        int $errorCode = null,
+        string $message = null
+    ): bool {
         $this->logger->critical(__('Message has been rejected: %1', $message));
 
         return $this->operationManagement->changeOperationStatus(

--- a/Model/EsIndex.php
+++ b/Model/EsIndex.php
@@ -28,6 +28,9 @@ class EsIndex extends AbstractSimpleObject implements EsIndexInterface
         return (string)$this->_get(self::INDEX_NAME);
     }
 
+    /**
+     * @return $this
+     */
     public function setIndexName(string $value)
     {
         return $this->setData(self::INDEX_NAME, $value);

--- a/Model/Field/FieldExtended.php
+++ b/Model/Field/FieldExtended.php
@@ -24,11 +24,7 @@ class FieldExtended implements FieldExtendedInterface
     {
         $this->field = $field;
     }
-
-
-    /**
-     * @return bool
-     */
+    
     public function isSearchable(): bool
     {
         return $this->field->getIsQuery()

--- a/Model/Hierarchy/Field/Handler/HierarchyId.php
+++ b/Model/Hierarchy/Field/Handler/HierarchyId.php
@@ -23,6 +23,9 @@ use Magento\Framework\DataObject;
  */
 class HierarchyId implements FieldHandlerInterface
 {
+    /**
+     * @return int
+     */
     public function handle(DataObject $item, string $fieldName)
     {
         return (int)$item->getId();

--- a/Model/Hierarchy/Field/Handler/IsActive.php
+++ b/Model/Hierarchy/Field/Handler/IsActive.php
@@ -23,6 +23,9 @@ use Magento\Framework\DataObject;
  */
 class IsActive implements FieldHandlerInterface
 {
+    /**
+     * @return bool
+     */
     public function handle(DataObject $item, string $fieldName)
     {
         return (bool)$item->getIsActive();

--- a/Model/Hierarchy/Field/Handler/Name.php
+++ b/Model/Hierarchy/Field/Handler/Name.php
@@ -25,12 +25,15 @@ class Name implements FieldHandlerInterface
 {
     public const PARENT_HIERARCHY_NAME = 'category';
 
+    /**
+     * @return string
+     */
     public function handle(DataObject $item, string $fieldName)
     {
         if ($item->getLevel() == 1) {
             return self::PARENT_HIERARCHY_NAME;
         } else {
-            return $item->getName();
+            return (string)$item->getName();
         }
     }
 }

--- a/Model/Hierarchy/Field/Handler/ParentHierarchyId.php
+++ b/Model/Hierarchy/Field/Handler/ParentHierarchyId.php
@@ -23,6 +23,9 @@ use Magento\Framework\DataObject;
  */
 class ParentHierarchyId implements FieldHandlerInterface
 {
+    /**
+     * @return int
+     */
     public function handle(DataObject $item, string $fieldName)
     {
         if ($item->getLevel() == 1) {

--- a/Model/HierarchyManagement.php
+++ b/Model/HierarchyManagement.php
@@ -36,14 +36,14 @@ class HierarchyManagement implements HierarchyManagementInterface
      */
     public function __construct(
         InstructionManagerPoolInterface $instructionManagerPool
-    )
-    {
+    ) {
         $this->instructionManagerPool = $instructionManagerPool;
     }
 
     /**
-     * @throws NotFoundException
+     * @return void
      * @throws InstructionException
+     * @throws NotFoundException
      */
     public function upsertHierarchy(array $items, string $indexName)
     {
@@ -61,8 +61,9 @@ class HierarchyManagement implements HierarchyManagementInterface
     }
 
     /**
-     * @throws NotFoundException
+     * @return void
      * @throws InstructionException
+     * @throws NotFoundException
      */
     public function rebuildHierarchy(string $indexName)
     {
@@ -74,6 +75,9 @@ class HierarchyManagement implements HierarchyManagementInterface
             ->get('hawksearch-esindexing')->executeByCode('rebuildHierarchy', $data)->get();
     }
 
+    /**
+     * @return void
+     */
     public function deleteHierarchyItems(array $ids, string $indexName)
     {
         if (!$ids) {

--- a/Model/IndexList.php
+++ b/Model/IndexList.php
@@ -26,6 +26,9 @@ class IndexList extends AbstractSimpleObject implements IndexListInterface
         return (array)$this->_get(self::FIELD_INDEX_NAMES);
     }
 
+    /**
+     * @return $this
+     */
     public function setIndexNames(array $value)
     {
         return $this->setData(self::FIELD_INDEX_NAMES, $value);

--- a/Model/IndexManagement.php
+++ b/Model/IndexManagement.php
@@ -64,6 +64,9 @@ class IndexManagement implements IndexManagementInterface
         $this->storeManager = $storeManager;
     }
 
+    /**
+     * @return void
+     */
     public function initializeFullReindex()
     {
         $this->hawkLogger->info("--- initializeFullReindex STARTED ---");
@@ -82,6 +85,9 @@ class IndexManagement implements IndexManagementInterface
         $this->hawkLogger->info("--- initializeFullReindex FINISHED ---");
     }
 
+    /**
+     * @return string|null
+     */
     public function getIndexName(bool $useCurrent = false): ?string
     {
         $indices = $this->getIndices();
@@ -104,6 +110,7 @@ class IndexManagement implements IndexManagementInterface
     }
 
     /**
+     * @return void
      * @throws InstructionException
      * @throws NoSuchEntityException
      * @throws NotFoundException
@@ -137,9 +144,10 @@ class IndexManagement implements IndexManagementInterface
     }
 
     /**
-     * @throws InstructionException
+     * @return void
      * @throws NoSuchEntityException
      * @throws NotFoundException
+     * @throws InstructionException
      */
     public function switchIndices()
     {
@@ -158,8 +166,9 @@ class IndexManagement implements IndexManagementInterface
     }
 
     /**
-     * @throws NotFoundException
+     * @return void
      * @throws InstructionException
+     * @throws NotFoundException
      */
     public function indexItems(array $items, string $indexName)
     {
@@ -179,8 +188,9 @@ class IndexManagement implements IndexManagementInterface
     }
 
     /**
-     * @throws NotFoundException
+     * @return void
      * @throws InstructionException
+     * @throws NotFoundException
      */
     public function deleteItems(array $ids, string $indexName)
     {

--- a/Model/Indexer/Category.php
+++ b/Model/Indexer/Category.php
@@ -25,9 +25,6 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 
 class Category implements IndexerActionInterface, MviewActionInterface
 {
-    /**
-     * Indexer ID in configuration
-     */
     const INDEXER_ID = 'hawksearch_categories';
 
     private Action $action;
@@ -36,8 +33,7 @@ class Category implements IndexerActionInterface, MviewActionInterface
     public function __construct(
         Action $action,
         ConsoleOutput $output
-    )
-    {
+    ) {
         $this->action = $action;
         $this->output = $output;
     }
@@ -45,6 +41,7 @@ class Category implements IndexerActionInterface, MviewActionInterface
     /**
      * This indexer is not designed to run full reindex
      *
+     * @return void
      * @see Entities
      */
     public function executeFull()
@@ -57,19 +54,26 @@ class Category implements IndexerActionInterface, MviewActionInterface
         $this->output->writeln('<comment>' . $phrase . '</comment>');
     }
 
+    /**
+     * @return void
+     */
     public function executeList(array $ids)
     {
         $this->execute($ids);
     }
 
+    /**
+     * @return void
+     */
     public function executeRow($id)
     {
         $this->execute([$id]);
     }
 
     /**
-     * @throws NoSuchEntityException
+     * @return void
      * @throws InputException
+     * @throws NoSuchEntityException
      */
     public function execute($ids)
     {

--- a/Model/Indexer/ContentPage.php
+++ b/Model/Indexer/ContentPage.php
@@ -24,9 +24,6 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 
 class ContentPage implements IndexerActionInterface, MviewActionInterface
 {
-    /**
-     * Indexer ID in configuration
-     */
     const INDEXER_ID = 'hawksearch_content_pages';
 
     private Action $action;
@@ -35,8 +32,7 @@ class ContentPage implements IndexerActionInterface, MviewActionInterface
     public function __construct(
         Action $action,
         ConsoleOutput $output
-    )
-    {
+    ) {
         $this->action = $action;
         $this->output = $output;
     }
@@ -44,6 +40,7 @@ class ContentPage implements IndexerActionInterface, MviewActionInterface
     /**
      * This indexer is not designed to run full reindex
      *
+     * @return void
      * @see Entities
      */
     public function executeFull()
@@ -56,19 +53,26 @@ class ContentPage implements IndexerActionInterface, MviewActionInterface
         $this->output->writeln('<comment>' . $phrase . '</comment>');
     }
 
+    /**
+     * @return void
+     */
     public function executeList(array $ids)
     {
         $this->execute($ids);
     }
 
+    /**
+     * @return void
+     */
     public function executeRow($id)
     {
         $this->execute([$id]);
     }
 
     /**
-     * @throws NoSuchEntityException
+     * @return void
      * @throws InputException
+     * @throws NoSuchEntityException
      */
     public function execute($ids)
     {

--- a/Model/Indexer/Entities.php
+++ b/Model/Indexer/Entities.php
@@ -19,20 +19,19 @@ use Magento\Framework\Indexer\ActionInterface;
 
 class Entities implements ActionInterface
 {
-    /**
-     * Indexer ID in configuration
-     */
     const INDEXER_ID = 'hawksearch_entities';
 
     private Action $action;
 
     public function __construct(
         Action $action
-    )
-    {
+    ) {
         $this->action = $action;
     }
 
+    /**
+     * @return void
+     */
     public function executeFull()
     {
         $this->action->execute();
@@ -40,15 +39,15 @@ class Entities implements ActionInterface
 
     /**
      * This indexer is not designed to run partial index updates
+     *
+     * @return void
      */
-    public function executeList(array $ids)
-    {
-    }
+    public function executeList(array $ids) {}
 
     /**
      * This indexer is not designed to run partial index updates
+     *
+     * @return void
      */
-    public function executeRow($id)
-    {
-    }
+    public function executeRow($id) {}
 }

--- a/Model/Indexer/Entities/ActionEntityDefault.php
+++ b/Model/Indexer/Entities/ActionEntityDefault.php
@@ -33,8 +33,7 @@ class ActionEntityDefault extends ActionAbstract
         SchedulerInterface $entityScheduler,
         StoreManagerInterface $storeManager,
         IndexingConfig $indexingConfig
-    )
-    {
+    ) {
         parent::__construct(
             $eventManager,
             $messageManager,
@@ -46,6 +45,7 @@ class ActionEntityDefault extends ActionAbstract
     }
 
     /**
+     * @return $this
      * @throws LocalizedException
      */
     public function execute(array $ids)

--- a/Model/Indexer/Entities/ActionFull.php
+++ b/Model/Indexer/Entities/ActionFull.php
@@ -33,8 +33,7 @@ class ActionFull extends ActionAbstract
         SchedulerInterface $entityScheduler,
         StoreManagerInterface $storeManager,
         IndexingConfig $indexingConfig
-    )
-    {
+    ) {
         parent::__construct(
             $eventManager,
             $messageManager,
@@ -49,6 +48,7 @@ class ActionFull extends ActionAbstract
      * Execute full reindex action
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @return $this
      * @throws LocalizedException
      */
     public function execute(?array $ids = null)

--- a/Model/Indexer/Entities/SchedulerAbstract.php
+++ b/Model/Indexer/Entities/SchedulerAbstract.php
@@ -40,8 +40,7 @@ class SchedulerAbstract implements SchedulerInterface
         EntityTypeInterface $entityType,
         MessageManagerInterface $messageManager,
         MessageTopicResolverInterface $messageTopicResolver
-    )
-    {
+    ) {
         $this->eventManager = $eventManager;
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;
         $this->entityType = $entityType;
@@ -50,6 +49,7 @@ class SchedulerAbstract implements SchedulerInterface
     }
 
     /**
+     * @return void
      * @throws InputException
      */
     public function schedule(StoreInterface $store, ?array $ids = null)

--- a/Model/Indexer/Entities/SchedulerComposite.php
+++ b/Model/Indexer/Entities/SchedulerComposite.php
@@ -50,8 +50,7 @@ class SchedulerComposite implements SchedulerInterface
     public function __construct(
         TMapFactory $tmapFactory,
         array $schedulers = []
-    )
-    {
+    ) {
         $this->schedulers = $tmapFactory->create(
             [
                 'array' => $schedulers,
@@ -60,6 +59,9 @@ class SchedulerComposite implements SchedulerInterface
         );
     }
 
+    /**
+     * @return void
+     */
     public function schedule(StoreInterface $store, ?array $ids = null)
     {
         foreach ($this->schedulers as $scheduler) {

--- a/Model/Indexer/Product.php
+++ b/Model/Indexer/Product.php
@@ -25,9 +25,6 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 
 class Product implements IndexerActionInterface, MviewActionInterface
 {
-    /**
-     * Indexer ID in configuration
-     */
     const INDEXER_ID = 'hawksearch_products';
 
     private ProductDataProvider $productDataProvider;
@@ -38,8 +35,7 @@ class Product implements IndexerActionInterface, MviewActionInterface
         ProductDataProvider $productDataProvider,
         Action $action,
         ConsoleOutput $output
-    )
-    {
+    ) {
         $this->productDataProvider = $productDataProvider;
         $this->action = $action;
         $this->output = $output;
@@ -48,6 +44,7 @@ class Product implements IndexerActionInterface, MviewActionInterface
     /**
      * This indexer is not designed to run full reindex
      *
+     * @return void
      * @see Entities
      */
     public function executeFull()
@@ -61,6 +58,7 @@ class Product implements IndexerActionInterface, MviewActionInterface
     }
 
     /**
+     * @return void
      * @throws LocalizedException
      */
     public function executeList(array $ids)
@@ -69,6 +67,7 @@ class Product implements IndexerActionInterface, MviewActionInterface
     }
 
     /**
+     * @return void
      * @throws LocalizedException
      */
     public function executeRow($id)
@@ -77,6 +76,7 @@ class Product implements IndexerActionInterface, MviewActionInterface
     }
 
     /**
+     * @return void
      * @throws LocalizedException
      */
     public function execute($ids)

--- a/Model/Indexing/AbstractEntityRebuild.php
+++ b/Model/Indexing/AbstractEntityRebuild.php
@@ -50,7 +50,6 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
             'description' => "The method will be removed. Using of 'code' and 'value' options is deprecated. Use " . FieldHandlerInterface::class . " to migrate fields with values."
         ]
     ];
-
     private array $deprecatedPublicProperties = [
         'entityTypePool' => [
             'since' => '0.8.0',
@@ -73,6 +72,7 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
             'description' => 'Visibility changed to private. Set via constructor injection.'
         ],
     ];
+
     /**
      * @var array<string, int>
      */
@@ -82,28 +82,23 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
      */
     private array $itemsToIndexCache = [];
     private EntityTypeInterface $entityType;
-
     /**
      * @var EntityTypePoolInterface<string, EntityTypeInterface>
      * @private 0.8.0 Visibility changed to private. Set via constructor injection.
      */
     private EntityTypePoolInterface $entityTypePool;
-
     /**
      * @private 0.8.0 Visibility changed to private. Set via constructor injection.
      */
     private EventManagerInterface $eventManager;
-
     /**
      * @private 0.8.0 Visibility changed to private. Set via constructor injection.
      */
     private LoggerInterface $hawkLogger;
-
     /**
      * @private 0.8.0 Visibility changed to private. Set via constructor injection.
      */
     private StoreManagerInterface $storeManager;
-
     /**
      * @private 0.8.0 Visibility changed to private. Set via constructor injection.
      */
@@ -162,6 +157,11 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
      */
     abstract protected function getEntityId(DataObject $entityItem): ?int;
 
+    /**
+     * @return void
+     * @throws LocalizedException
+     * @throws NotFoundException
+     */
     public function rebuild(SearchCriteriaInterface $searchCriteria)
     {
         if (!$this->getEntityType()->getConfigHelper()->isEnabled()) {
@@ -182,7 +182,6 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
             $this->rebuildBatch($searchCriteria, $ids);
         }
     }
-
 
     /**
      * Rebuild one batch of Entity items
@@ -318,7 +317,7 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
     /**
      * @param TItem[] $fullItemsList Full list of items to be indexed
      * @param array<int>|null $entityIds List of entity IDs used for items selection
-     * @return array
+     * @return array<int, TItem>
      * @throws LocalizedException
      * @todo $entityIds: remove unused argument
      */
@@ -345,7 +344,7 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
 
     /**
      * @param TItem $item
-     * @return array
+     * @return array<array-key, list<mixed>>
      * @throws LocalizedException
      */
     protected function convertEntityToIndexDataArray(DataObject $item): array
@@ -422,7 +421,7 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
     }
 
     /**
-     * @return mixed
+     * @return list<mixed>|null
      */
     protected function castAttributeValue(mixed $value)
     {
@@ -448,7 +447,7 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
      *     values.
      * @see FieldNameProviderInterface
      */
-    protected function getIndexedAttributes(DataObject $item = null): array
+    protected function getIndexedAttributes(DataObject $item = null): array // @phpstan-ignore-line
     {
         return [];
     }
@@ -504,7 +503,6 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
     }
 
     /**
-     * @return EntityTypeInterface
      * @throws NotFoundException
      * @todo Refactor and get rid of iterating EntityTypePool
      */
@@ -575,6 +573,7 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
     /**
      * @param TItem[] $items Key of an array item is item ID
      * @param string $indexName
+     * @return void
      * @throws LocalizedException
      * @throws NotFoundException
      */
@@ -616,6 +615,7 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
     /**
      * @param string[] $ids
      * @param string $indexName
+     * @return void
      * @throws NotFoundException
      */
     protected function deleteIndexItems(array $ids, string $indexName)

--- a/Model/Indexing/Context.php
+++ b/Model/Indexing/Context.php
@@ -22,21 +22,33 @@ class Context implements ContextInterface
     private array $indexNameCache = [];
     private bool $isFullReindex = false;
 
+    /**
+     * @return void
+     */
     public function setIndexName(int $storeId, string $indexName)
     {
         $this->indexNameCache[$storeId] = $indexName;
     }
 
+    /**
+     * @return string
+     */
     public function getIndexName(int $storeId)
     {
         return $this->indexNameCache[$storeId] ?? '';
     }
 
+    /**
+     * @return void
+     */
     public function setIsFullReindex(bool $isFull)
     {
         $this->isFullReindex = $isFull;
     }
 
+    /**
+     * @return bool
+     */
     public function isFullReindex()
     {
         return $this->isFullReindex;

--- a/Model/Indexing/Entity/ContentPage/ItemsDataProvider.php
+++ b/Model/Indexing/Entity/ContentPage/ItemsDataProvider.php
@@ -29,12 +29,15 @@ class ItemsDataProvider implements ItemsDataProviderInterface
     public function __construct(
         PageRepositoryInterface $pageRepository,
         SearchCriteriaBuilder $searchCriteriaBuilder
-    )
-    {
+    ) {
         $this->pageRepository = $pageRepository;
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;
     }
 
+    /**
+     * @return PageInterface[]
+     * @throws LocalizedException
+     */
     public function getItems(int $storeId, ?array $entityIds = null, int $currentPage = 1, int $pageSize = 0)
     {
         return $this->getPageCollection($storeId, $entityIds, $currentPage, $pageSize);

--- a/Model/Indexing/Entity/Hierarchy/EntityRebuild.php
+++ b/Model/Indexing/Entity/Hierarchy/EntityRebuild.php
@@ -45,7 +45,10 @@ class EntityRebuild extends AbstractEntityRebuild
     {
         return (int)$entityItem->getId();
     }
-    
+
+    /**
+     * @return mixed
+     */
     protected function castAttributeValue(mixed $value)
     {
         return $value === '' ? null : $value;

--- a/Model/Indexing/Entity/LandingPage/ConfigHelper.php
+++ b/Model/Indexing/Entity/LandingPage/ConfigHelper.php
@@ -25,18 +25,23 @@ class ConfigHelper extends AbstractConfigHelper
         IndexingConfig $indexingConfig,
         /** @todo change type: int -> ?int */
         int $batchSize = null
-    )
-    {
+    ) {
         parent::__construct($indexingConfig);
         $this->batchSize = $batchSize;
     }
 
+    /**
+     * @return bool
+     */
     public function isEnabled($store = null)
     {
         //@todo check if indexing of landing page entity is allowed
         return parent::isEnabled($store);
     }
 
+    /**
+     * @return int
+     */
     public function getBatchSize($store = null)
     {
         return $this->batchSize ?? parent::getBatchSize($store);

--- a/Model/Indexing/Entity/LandingPage/EntityRebuild.php
+++ b/Model/Indexing/Entity/LandingPage/EntityRebuild.php
@@ -151,7 +151,7 @@ class EntityRebuild extends AbstractEntityRebuild
     }
 
     /**
-     * @return array
+     * @return LandingPageInterface[]
      * @throws NoSuchEntityException
      */
     protected function getLandingPages()
@@ -164,7 +164,7 @@ class EntityRebuild extends AbstractEntityRebuild
     }
 
     /**
-     * @return array|LandingPageInterface[]
+     * @return LandingPageInterface[]
      * @throws NoSuchEntityException
      */
     protected function getCachedLandingPages()
@@ -194,7 +194,7 @@ class EntityRebuild extends AbstractEntityRebuild
     }
 
     /**
-     * @return LandingPageInterface[]
+     * @return array<string, LandingPageInterface>
      * @throws NoSuchEntityException
      */
     protected function getCustomFieldMap()
@@ -214,7 +214,7 @@ class EntityRebuild extends AbstractEntityRebuild
     }
 
     /**
-     * @return LandingPageInterface[]
+     * @return array<string, LandingPageInterface>
      * @throws NoSuchEntityException
      */
     protected function getCustomUrlMap()
@@ -236,6 +236,7 @@ class EntityRebuild extends AbstractEntityRebuild
     /**
      * Delete Landing pages by Custom field ids
      *
+     * @return void
      * @throws NoSuchEntityException
      * @throws NotFoundException
      */
@@ -288,6 +289,9 @@ class EntityRebuild extends AbstractEntityRebuild
         return $itemsToIndex;
     }
 
+    /**
+     * @return void
+     */
     protected function addIndexItems(array $items, string $indexName)
     {
         if (!$items) {
@@ -297,6 +301,9 @@ class EntityRebuild extends AbstractEntityRebuild
         $this->getEntityType()->getItemsIndexer()->add($this->convertItems($items), $indexName);
     }
 
+    /**
+     * @return void
+     */
     protected function updateIndexItems(array $items, string $indexName)
     {
         if (!$items) {

--- a/Model/Indexing/Entity/Product/ItemsDataProvider.php
+++ b/Model/Indexing/Entity/Product/ItemsDataProvider.php
@@ -58,8 +58,7 @@ class ItemsDataProvider implements ItemsDataProviderInterface
         CategoryCollectionFactory $categoryCollectionFactory,
         ExcludeNotVisibleProductsFlagInterface $excludeNotVisibleProductsFlag = null,
         ProductDataProvider $productDataProvider = null
-    )
-    {
+    ) {
         $this->productRepository = $productRepository;
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;
         $this->visibility = $visibility;
@@ -95,8 +94,12 @@ class ItemsDataProvider implements ItemsDataProviderInterface
      * @param int $pageSize
      * @return ItemType[]
      */
-    protected function getProductCollection(int $storeId, ?array $productIds = null, int $currentPage = 1, int $pageSize = 0): array
-    {
+    protected function getProductCollection(
+        int $storeId,
+        ?array $productIds = null,
+        int $currentPage = 1,
+        int $pageSize = 0
+    ): array {
         $this->searchCriteriaBuilder->addFilter('store_id', $storeId);
 
         if ($productIds && count($productIds) > 0) {

--- a/Model/Indexing/Entity/Product/Scheduler/ItemsDataProvider.php
+++ b/Model/Indexing/Entity/Product/Scheduler/ItemsDataProvider.php
@@ -14,8 +14,16 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\Indexing\Entity\Product\Scheduler;
 
-class ItemsDataProvider extends \HawkSearch\EsIndexing\Model\Indexing\Entity\Product\ItemsDataProvider
+use HawkSearch\EsIndexing\Model\Indexing\Entity\Product\ItemsDataProvider as ItemsDataProviderParent;
+
+/**
+ * @phpstan-import-type ItemType from ItemsDataProviderParent
+ */
+class ItemsDataProvider extends ItemsDataProviderParent
 {
+    /**
+     * @return ItemType[]
+     */
     public function getItems(int $storeId, ?array $entityIds = null, int $currentPage = 1, int $pageSize = 0)
     {
         return $this->getProductCollection($storeId, $entityIds, $currentPage, $pageSize);

--- a/Model/Indexing/EntityType/EntityTypeAbstract.php
+++ b/Model/Indexing/EntityType/EntityTypeAbstract.php
@@ -113,12 +113,18 @@ abstract class EntityTypeAbstract implements EntityTypeInterface
         return $this->typeName;
     }
 
+    /**
+     * @return $this
+     */
     public function setTypeName(string $type)
     {
         $this->typeName = $type;
         return $this;
     }
 
+    /**
+     * @return string
+     */
     public function getUniqueId(string $itemId)
     {
         return $this->getTypeName() . '_' . $itemId;

--- a/Model/Indexing/EntityTypePool.php
+++ b/Model/Indexing/EntityTypePool.php
@@ -41,8 +41,7 @@ class EntityTypePool implements EntityTypePoolInterface
     public function __construct(
         TMapFactory $tmapFactory,
         array $types = []
-    )
-    {
+    ) {
         $this->tmapFactory = $tmapFactory;
         $this->types = $tmapFactory->createSharedObjectsMap(
             [
@@ -87,6 +86,9 @@ class EntityTypePool implements EntityTypePoolInterface
         return $instances[$entityTypeName];
     }
 
+    /**
+     * @return TMap<TKey, TValue>
+     */
     public function getList()
     {
         return $this->types;

--- a/Model/Indexing/FieldHandler/Composite.php
+++ b/Model/Indexing/FieldHandler/Composite.php
@@ -59,8 +59,7 @@ class Composite implements FieldHandlerInterface
     public function __construct(
         ObjectManagerInterface $objectManager,
         array $handlers = []
-    )
-    {
+    ) {
         $this->objectManager = $objectManager;
         $this->mergeTypes($handlers);
     }
@@ -68,6 +67,7 @@ class Composite implements FieldHandlerInterface
     /**
      * @param TItem $item
      * @param key-of<HandlersMap> $fieldName
+     * @return mixed
      */
     public function handle(DataObject $item, string $fieldName)
     {

--- a/Model/Indexing/FieldHandler/DataObjectHandler.php
+++ b/Model/Indexing/FieldHandler/DataObjectHandler.php
@@ -25,6 +25,9 @@ use Magento\Framework\DataObject;
  */
 class DataObjectHandler implements FieldHandlerInterface
 {
+    /**
+     * @return mixed
+     */
     public function handle(DataObject $item, string $fieldName)
     {
         return $item->getData($fieldName);

--- a/Model/Indexing/ItemsIndexer/HierarchyItemsIndexer.php
+++ b/Model/Indexing/ItemsIndexer/HierarchyItemsIndexer.php
@@ -26,11 +26,13 @@ class HierarchyItemsIndexer implements ItemsIndexerInterface
 
     public function __construct(
         HierarchyManagementInterface $hierarchyManagement
-    )
-    {
+    ) {
         $this->hierarchyManagement = $hierarchyManagement;
     }
 
+    /**
+     * @return void
+     */
     public function add(array $items, string $indexName)
     {
         $this->update($items, $indexName);
@@ -38,6 +40,8 @@ class HierarchyItemsIndexer implements ItemsIndexerInterface
 
     /**
      * Uses hierarchy API to upsert hierarchy items
+     *
+     * @return void
      */
     public function update(array $items, string $indexName)
     {
@@ -46,6 +50,8 @@ class HierarchyItemsIndexer implements ItemsIndexerInterface
 
     /**
      * Uses hierarchy API to remove hierarchy items
+     *
+     * @return void
      */
     public function delete(array $items, string $indexName)
     {

--- a/Model/Indexing/ItemsIndexer/LandingPageItemsIndexer.php
+++ b/Model/Indexing/ItemsIndexer/LandingPageItemsIndexer.php
@@ -27,14 +27,14 @@ class LandingPageItemsIndexer implements ItemsIndexerInterface
 
     public function __construct(
         LandingPageManagementInterface $landingPageManagement
-    )
-    {
+    ) {
         $this->landingPageManagement = $landingPageManagement;
     }
 
     /**
      * @param LandingPageInterface[] $items
      * @param string $indexName
+     * @return void
      */
     public function add(array $items, string $indexName)
     {
@@ -46,6 +46,7 @@ class LandingPageItemsIndexer implements ItemsIndexerInterface
      *
      * @param LandingPageInterface[] $items
      * @param string $indexName
+     * @return void
      */
     public function update(array $items, string $indexName)
     {
@@ -54,6 +55,8 @@ class LandingPageItemsIndexer implements ItemsIndexerInterface
 
     /**
      * Uses hierarchy API to remove hierarchy items
+     *
+     * @return void
      */
     public function delete(array $items, string $indexName)
     {

--- a/Model/Indexing/ItemsIndexer/SearchedItemsIndexer.php
+++ b/Model/Indexing/ItemsIndexer/SearchedItemsIndexer.php
@@ -35,14 +35,14 @@ class SearchedItemsIndexer implements ItemsIndexerInterface
      */
     public function __construct(
         InstructionManagerPoolInterface $instructionManagerPool
-    )
-    {
+    ) {
         $this->instructionManagerPool = $instructionManagerPool;
     }
 
     /**
-     * @throws InstructionException
+     * @return void
      * @throws NotFoundException
+     * @throws InstructionException
      */
     public function add(array $items, string $indexName)
     {
@@ -52,8 +52,9 @@ class SearchedItemsIndexer implements ItemsIndexerInterface
     /**
      * Uses api/v2/indexing/index-ixtems API call for items indexing
      *
-     * @throws InstructionException
+     * @return void
      * @throws NotFoundException
+     * @throws InstructionException
      */
     public function update(array $items, string $indexName)
     {
@@ -75,8 +76,9 @@ class SearchedItemsIndexer implements ItemsIndexerInterface
     /**
      * Uses api/v2/indexing/delete-items API call for removing items from the index
      *
-     * @throws InstructionException
+     * @return void
      * @throws NotFoundException
+     * @throws InstructionException
      */
     public function delete(array $items, string $indexName)
     {

--- a/Model/LandingPage.php
+++ b/Model/LandingPage.php
@@ -19,12 +19,14 @@ use Magento\Framework\Api\AbstractSimpleObject;
 
 class LandingPage extends AbstractSimpleObject implements LandingPageInterface
 {
-
     public function getPageId(): ?int
     {
         return (int)$this->_get(self::FIELD_PAGE_ID);
     }
 
+    /**
+     * @return $this
+     */
     public function setPageId(?int $value)
     {
         return $this->setData(self::FIELD_PAGE_ID, $value);
@@ -35,6 +37,9 @@ class LandingPage extends AbstractSimpleObject implements LandingPageInterface
         return $this->_get(self::FIELD_SYNC_GUID);
     }
 
+    /**
+     * @return $this
+     */
     public function setSyncGuid(?string $value)
     {
         return $this->setData(self::FIELD_SYNC_GUID, $value);
@@ -45,6 +50,9 @@ class LandingPage extends AbstractSimpleObject implements LandingPageInterface
         return $this->_get(self::FIELD_NAME);
     }
 
+    /**
+     * @return $this
+     */
     public function setName(?string $value)
     {
         return $this->setData(self::FIELD_NAME, $value);
@@ -55,6 +63,9 @@ class LandingPage extends AbstractSimpleObject implements LandingPageInterface
         return $this->_get(self::FIELD_CUSTOM_URL);
     }
 
+    /**
+     * @return $this
+     */
     public function setCustomUrl(?string $value)
     {
         return $this->setData(self::FIELD_CUSTOM_URL, $value);
@@ -65,6 +76,9 @@ class LandingPage extends AbstractSimpleObject implements LandingPageInterface
         return $this->_get(self::FIELD_NARROW_XML);
     }
 
+    /**
+     * @return $this
+     */
     public function setNarrowXml(?string $value)
     {
         return $this->setData(self::FIELD_NARROW_XML, $value);
@@ -75,6 +89,9 @@ class LandingPage extends AbstractSimpleObject implements LandingPageInterface
         return (bool)$this->_get(self::FIELD_IS_FACET_OVERRIDE);
     }
 
+    /**
+     * @return $this
+     */
     public function setIsFacetOverride(bool $value)
     {
         return $this->setData(self::FIELD_IS_FACET_OVERRIDE, $value);
@@ -85,6 +102,9 @@ class LandingPage extends AbstractSimpleObject implements LandingPageInterface
         return (bool)$this->_get(self::FIELD_IS_INCLUDE_PRODUCTS);
     }
 
+    /**
+     * @return $this
+     */
     public function setIsIncludeProducts(bool $value)
     {
         return $this->setData(self::FIELD_IS_INCLUDE_PRODUCTS, $value);
@@ -95,6 +115,9 @@ class LandingPage extends AbstractSimpleObject implements LandingPageInterface
         return $this->_get(self::FIELD_SORT_FIELD_ID);
     }
 
+    /**
+     * @return $this
+     */
     public function setSortFieldId(?string $value)
     {
         return $this->setData(self::FIELD_SORT_FIELD_ID, $value);
@@ -105,6 +128,9 @@ class LandingPage extends AbstractSimpleObject implements LandingPageInterface
         return $this->_get(self::FIELD_SORT_DIRECTION);
     }
 
+    /**
+     * @return $this
+     */
     public function setSortDirection(?string $value)
     {
         return $this->setData(self::FIELD_SORT_DIRECTION, $value);
@@ -115,6 +141,9 @@ class LandingPage extends AbstractSimpleObject implements LandingPageInterface
         return (array)$this->_get(self::FIELD_SELECTED_FACETS);
     }
 
+    /**
+     * @return $this
+     */
     public function setSelectedFacets(array $value)
     {
         return $this->setData(self::FIELD_SELECTED_FACETS, $value);
@@ -125,6 +154,9 @@ class LandingPage extends AbstractSimpleObject implements LandingPageInterface
         return $this->_get(self::FIELD_PAGE_LAYOUT_ID);
     }
 
+    /**
+     * @return $this
+     */
     public function setPageLayoutId(?string $value)
     {
         return $this->setData(self::FIELD_PAGE_LAYOUT_ID, $value);
@@ -135,6 +167,9 @@ class LandingPage extends AbstractSimpleObject implements LandingPageInterface
         return (bool)$this->_get(self::FIELD_ENABLE_FACET_AUTO_ORDERING);
     }
 
+    /**
+     * @return $this
+     */
     public function setEnableFacetAutoOrdering(bool $value)
     {
         return $this->setData(self::FIELD_ENABLE_FACET_AUTO_ORDERING, $value);
@@ -145,6 +180,9 @@ class LandingPage extends AbstractSimpleObject implements LandingPageInterface
         return $this->_get(self::FIELD_CUSTOM);
     }
 
+    /**
+     * @return $this
+     */
     public function setCustom(?string $value)
     {
         return $this->setData(self::FIELD_CUSTOM, $value);
@@ -155,6 +193,9 @@ class LandingPage extends AbstractSimpleObject implements LandingPageInterface
         return $this->_get(self::FIELD_TAGS);
     }
 
+    /**
+     * @return $this
+     */
     public function setTags(?string $value)
     {
         return $this->setData(self::FIELD_TAGS, $value);
@@ -165,6 +206,9 @@ class LandingPage extends AbstractSimpleObject implements LandingPageInterface
         return $this->_get(self::FIELD_CANONICAL_URL);
     }
 
+    /**
+     * @return $this
+     */
     public function setCanonicalUrl(?string $value)
     {
         return $this->setData(self::FIELD_CANONICAL_URL, $value);
@@ -175,6 +219,9 @@ class LandingPage extends AbstractSimpleObject implements LandingPageInterface
         return $this->_get(self::FIELD_PAGE_TYPE);
     }
 
+    /**
+     * @return $this
+     */
     public function setPageType(?string $value)
     {
         return $this->setData(self::FIELD_PAGE_TYPE, $value);
@@ -185,6 +232,9 @@ class LandingPage extends AbstractSimpleObject implements LandingPageInterface
         return (array)$this->_get(self::FIELD_CONTENT_CONFIG_LIST);
     }
 
+    /**
+     * @return $this
+     */
     public function setContentConfigList(array $value)
     {
         return $this->setData(self::FIELD_CONTENT_CONFIG_LIST, $value);
@@ -195,6 +245,9 @@ class LandingPage extends AbstractSimpleObject implements LandingPageInterface
         return $this->_get(self::FIELD_PAGE_HEADING);
     }
 
+    /**
+     * @return $this
+     */
     public function setPageHeading(?string $value)
     {
         return $this->setData(self::FIELD_PAGE_HEADING, $value);
@@ -205,6 +258,9 @@ class LandingPage extends AbstractSimpleObject implements LandingPageInterface
         return $this->_get(self::FIELD_CUSTOM_HTML);
     }
 
+    /**
+     * @return $this
+     */
     public function setCustomHtml(?string $value)
     {
         return $this->setData(self::FIELD_CUSTOM_HTML, $value);
@@ -215,6 +271,9 @@ class LandingPage extends AbstractSimpleObject implements LandingPageInterface
         return $this->_get(self::FIELD_KEYWORDS);
     }
 
+    /**
+     * @return $this
+     */
     public function setKeywords(?string $value)
     {
         return $this->setData(self::FIELD_KEYWORDS, $value);
@@ -225,6 +284,9 @@ class LandingPage extends AbstractSimpleObject implements LandingPageInterface
         return $this->_get(self::FIELD_LIST_NAME);
     }
 
+    /**
+     * @return $this
+     */
     public function setListName(?string $value)
     {
         return $this->setData(self::FIELD_LIST_NAME, $value);
@@ -235,6 +297,9 @@ class LandingPage extends AbstractSimpleObject implements LandingPageInterface
         return $this->_get(self::FIELD_NOTES);
     }
 
+    /**
+     * @return $this
+     */
     public function setNotes(?string $value)
     {
         return $this->setData(self::FIELD_NOTES, $value);
@@ -245,6 +310,9 @@ class LandingPage extends AbstractSimpleObject implements LandingPageInterface
         return $this->_get(self::FIELD_CREATE_DATE);
     }
 
+    /**
+     * @return $this
+     */
     public function setCreateDate(?string $value)
     {
         return $this->setData(self::FIELD_CREATE_DATE, $value);
@@ -255,6 +323,9 @@ class LandingPage extends AbstractSimpleObject implements LandingPageInterface
         return $this->_get(self::FIELD_MODIFY_DATE);
     }
 
+    /**
+     * @return $this
+     */
     public function setModifyDate(?string $value)
     {
         return $this->setData(self::FIELD_MODIFY_DATE, $value);
@@ -265,6 +336,9 @@ class LandingPage extends AbstractSimpleObject implements LandingPageInterface
         return (bool)$this->_get(self::FIELD_IS_NO_INDEX);
     }
 
+    /**
+     * @return $this
+     */
     public function setIsNoIndex(bool $value)
     {
         return $this->setData(self::FIELD_IS_NO_INDEX, $value);
@@ -275,6 +349,9 @@ class LandingPage extends AbstractSimpleObject implements LandingPageInterface
         return (bool)$this->_get(self::FIELD_IS_NO_FOLLOW);
     }
 
+    /**
+     * @return $this
+     */
     public function setIsNoFollow(bool $value)
     {
         return $this->setData(self::FIELD_IS_NO_FOLLOW, $value);
@@ -285,6 +362,9 @@ class LandingPage extends AbstractSimpleObject implements LandingPageInterface
         return $this->_get(self::FIELD_CUSTOM_SORT_LIST);
     }
 
+    /**
+     * @return $this
+     */
     public function setCustomSortList(?string $value)
     {
         return $this->setData(self::FIELD_CUSTOM_SORT_LIST, $value);

--- a/Model/LandingPage/Field/Handler/Custom.php
+++ b/Model/LandingPage/Field/Handler/Custom.php
@@ -25,6 +25,9 @@ class Custom implements FieldHandlerInterface
 {
     public const CUSTOM_FIELD_PREFIX = "__mage_catid__";
 
+    /**
+     * @return string
+     */
     public function handle(DataObject $item, string $fieldName)
     {
         return self::CUSTOM_FIELD_PREFIX . $item->getId();

--- a/Model/LandingPage/Field/Handler/CustomSortList.php
+++ b/Model/LandingPage/Field/Handler/CustomSortList.php
@@ -32,6 +32,9 @@ class CustomSortList implements FieldHandlerInterface
         $this->productEntityTypeFactory = $productEntityTypeFactory;
     }
 
+    /**
+     * @return string
+     */
     public function handle(DataObject $item, string $fieldName)
     {
         $positionsHash = $item->getProductsPosition();

--- a/Model/LandingPage/Field/Handler/CustomUrl.php
+++ b/Model/LandingPage/Field/Handler/CustomUrl.php
@@ -24,6 +24,7 @@ use Magento\Framework\DataObject;
 class CustomUrl implements FieldHandlerInterface
 {
     /**
+     * @return string
      * @todo implement handler which can get other attribute values or has access to the final entity
      */
     public function handle(DataObject $item, string $fieldName)

--- a/Model/LandingPage/Field/Handler/DefaultHandler.php
+++ b/Model/LandingPage/Field/Handler/DefaultHandler.php
@@ -27,6 +27,9 @@ class DefaultHandler extends DataObjectHandler
         $this->dataObjectHelper = $dataObjectHelper;
     }
 
+    /**
+     * @return mixed
+     */
     public function handle(DataObject $item, string $fieldName)
     {
         $fieldName = $this->dataObjectHelper->camelCaseToSnakeCase($fieldName);

--- a/Model/LandingPage/Field/Handler/IsFacetOverride.php
+++ b/Model/LandingPage/Field/Handler/IsFacetOverride.php
@@ -23,6 +23,9 @@ use Magento\Framework\DataObject;
  */
 class IsFacetOverride implements FieldHandlerInterface
 {
+    /**
+     * @return false
+     */
     public function handle(DataObject $item, string $fieldName)
     {
         return false;

--- a/Model/LandingPage/Field/Handler/NarrowXml.php
+++ b/Model/LandingPage/Field/Handler/NarrowXml.php
@@ -23,6 +23,9 @@ use Magento\Framework\DataObject;
  */
 class NarrowXml implements FieldHandlerInterface
 {
+    /**
+     * @return string
+     */
     public function handle(DataObject $item, string $fieldName)
     {
         $xml = simplexml_load_string(

--- a/Model/LandingPage/Field/Handler/PageType.php
+++ b/Model/LandingPage/Field/Handler/PageType.php
@@ -23,6 +23,9 @@ use Magento\Framework\DataObject;
  */
 class PageType implements FieldHandlerInterface
 {
+    /**
+     * @return string
+     */
     public function handle(DataObject $item, string $fieldName)
     {
         return 'ProductListing';

--- a/Model/LandingPageManagement.php
+++ b/Model/LandingPageManagement.php
@@ -16,7 +16,10 @@ namespace HawkSearch\EsIndexing\Model;
 
 use HawkSearch\Connector\Gateway\Instruction\InstructionManagerInterface;
 use HawkSearch\Connector\Gateway\Instruction\InstructionManagerPoolInterface;
+use HawkSearch\Connector\Gateway\InstructionException;
+use HawkSearch\EsIndexing\Api\Data\LandingPageInterface;
 use HawkSearch\EsIndexing\Api\LandingPageManagementInterface;
+use Magento\Framework\Exception\NotFoundException;
 
 /**
  * @api
@@ -36,35 +39,53 @@ class LandingPageManagement implements LandingPageManagementInterface
      */
     public function __construct(
         InstructionManagerPoolInterface $instructionManagerPool
-    )
-    {
+    ) {
         $this->instructionManagerPool = $instructionManagerPool;
     }
 
+    /**
+     * @return LandingPageInterface[]
+     * @throws InstructionException
+     * @throws NotFoundException
+     */
     public function getLandingPages()
     {
         return $this->instructionManagerPool->get('hawksearch-esindexing')
             ->executeByCode('getLandingPages')->get();
     }
 
+    /**
+     * @return array<mixed>
+     * @throws InstructionException
+     * @throws NotFoundException
+     */
     public function getLandingPageUrls()
     {
         return $this->instructionManagerPool->get('hawksearch-esindexing')
             ->executeByCode('getLandingPageUrls')->get();
     }
 
+    /**
+     * @return void
+     */
     public function addLandingPages(array $landingPages)
     {
         $this->instructionManagerPool->get('hawksearch-esindexing')
             ->executeByCode('addLandingPagesBulk', $landingPages)->get();
     }
 
+    /**
+     * @return void
+     */
     public function updateLandingPages(array $landingPages)
     {
         $this->instructionManagerPool->get('hawksearch-esindexing')
             ->executeByCode('updateLandingPagesBulk', $landingPages)->get();
     }
 
+    /**
+     * @return void
+     */
     public function deleteLandingPages(array $landingPageIds, bool $safeDelete = false)
     {
         if (!$landingPageIds) {

--- a/Model/Layout/CompositeConfigProcessor.php
+++ b/Model/Layout/CompositeConfigProcessor.php
@@ -31,11 +31,13 @@ class CompositeConfigProcessor implements LayoutConfigProcessorInterface
      */
     public function __construct(
         array $configProcessors
-    )
-    {
+    ) {
         $this->configProcessors = $configProcessors;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function process(array $jsConfig)
     {
         foreach ($this->configProcessors as $configProcessor) {

--- a/Model/Layout/ConfigProcessor/JsGlobal/CatalogConfigProcessor.php
+++ b/Model/Layout/ConfigProcessor/JsGlobal/CatalogConfigProcessor.php
@@ -51,6 +51,8 @@ class CatalogConfigProcessor implements LayoutConfigProcessorInterface
     /**
      * Process configurations
      * Uses format supported by mage/utils/template templates syntax
+     *
+     * @return array<string, mixed>
      */
     public function process(array $jsConfig)
     {

--- a/Model/Layout/ConfigProcessor/JsGlobal/CommonConfigProcessor.php
+++ b/Model/Layout/ConfigProcessor/JsGlobal/CommonConfigProcessor.php
@@ -18,6 +18,9 @@ use HawkSearch\EsIndexing\Model\Layout\LayoutConfigProcessorInterface;
 
 class CommonConfigProcessor implements LayoutConfigProcessorInterface
 {
+    /**
+     * @return array<string, mixed>
+     */
     public function process(array $jsConfig)
     {
         $config = [

--- a/Model/Layout/ConfigProcessor/JsGlobal/PricingConfigProcessor.php
+++ b/Model/Layout/ConfigProcessor/JsGlobal/PricingConfigProcessor.php
@@ -32,8 +32,7 @@ class PricingConfigProcessor implements LayoutConfigProcessorInterface
         LocaleFormat $localeFormat,
         StoreManagerInterface $storeManager,
         PricingHelper $pricingHelper
-    )
-    {
+    ) {
         $this->localeFormat = $localeFormat;
         $this->storeManager = $storeManager;
         $this->pricingHelper = $pricingHelper;
@@ -42,6 +41,8 @@ class PricingConfigProcessor implements LayoutConfigProcessorInterface
     /**
      * Process configurations
      * Uses format supported by mage/utils/template templates syntax
+     *
+     * @return array<string, mixed>
      */
     public function process(array $jsConfig)
     {

--- a/Model/Layout/ConfigProcessor/JsGlobal/RequestConfigProcessor.php
+++ b/Model/Layout/ConfigProcessor/JsGlobal/RequestConfigProcessor.php
@@ -33,14 +33,16 @@ class RequestConfigProcessor implements LayoutConfigProcessorInterface
         RequestInterface $request,
         UrlInterface $urlBuilder,
         FormKey $formKey
-    )
-    {
+    ) {
         $this->searchHelper = $searchHelper;
         $this->request = $request;
         $this->urlBuilder = $urlBuilder;
         $this->formKey = $formKey;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function process(array $jsConfig)
     {
         $jsConfig['request'] = [

--- a/Model/Layout/ConfigProcessor/Vue/VueAdditionalParametersProcessor.php
+++ b/Model/Layout/ConfigProcessor/Vue/VueAdditionalParametersProcessor.php
@@ -38,6 +38,9 @@ class VueAdditionalParametersProcessor implements LayoutConfigProcessorInterface
         $this->urlFinder = $urlFinder;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function process(array $jsConfig)
     {
         $params = [];

--- a/Model/Layout/ConfigProcessor/Vue/VueConnectionConfigProcessor.php
+++ b/Model/Layout/ConfigProcessor/Vue/VueConnectionConfigProcessor.php
@@ -23,11 +23,14 @@ class VueConnectionConfigProcessor implements LayoutConfigProcessorInterface
 
     public function __construct(
         ApiSettings $apiSettings
-    )
-    {
+    ) {
         $this->apiSettings = $apiSettings;
     }
 
+
+    /**
+     * @return array<string, mixed>
+     */
     public function process(array $jsConfig)
     {
         $connectionConfig = [

--- a/Model/Layout/ConfigProcessor/Vue/VueParamsMappingProcessor.php
+++ b/Model/Layout/ConfigProcessor/Vue/VueParamsMappingProcessor.php
@@ -23,11 +23,13 @@ class VueParamsMappingProcessor implements LayoutConfigProcessorInterface
 
     public function __construct(
         SearchHelper $searchHelper
-    )
-    {
+    ) {
         $this->searchHelper = $searchHelper;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function process(array $jsConfig)
     {
         $jsConfig['paramsMapping'] = [

--- a/Model/Layout/ConfigProcessor/Vue/VueResultItemConfigProcessor.php
+++ b/Model/Layout/ConfigProcessor/Vue/VueResultItemConfigProcessor.php
@@ -18,6 +18,9 @@ use HawkSearch\EsIndexing\Model\Layout\LayoutConfigProcessorInterface;
 
 class VueResultItemConfigProcessor implements LayoutConfigProcessorInterface
 {
+    /**
+     * @return array<string, mixed>
+     */
     public function process(array $jsConfig)
     {
         $jsConfig['resultItem'] = [

--- a/Model/Layout/ConfigProcessor/Vue/VueSearchBoxConfigProcessor.php
+++ b/Model/Layout/ConfigProcessor/Vue/VueSearchBoxConfigProcessor.php
@@ -18,6 +18,9 @@ use HawkSearch\EsIndexing\Model\Layout\LayoutConfigProcessorInterface;
 
 class VueSearchBoxConfigProcessor implements LayoutConfigProcessorInterface
 {
+    /**
+     * @return array<string, mixed>
+     */
     public function process(array $jsConfig)
     {
         $jsConfig['searchBoxConfig'] = [

--- a/Model/Layout/ConfigProcessor/Vue/VueSearchConfigProcessor.php
+++ b/Model/Layout/ConfigProcessor/Vue/VueSearchConfigProcessor.php
@@ -18,6 +18,9 @@ use HawkSearch\EsIndexing\Model\Layout\LayoutConfigProcessorInterface;
 
 class VueSearchConfigProcessor implements LayoutConfigProcessorInterface
 {
+    /**
+     * @return array<string, mixed>
+     */
     public function process(array $jsConfig)
     {
         $jsConfig['searchConfig'] = [

--- a/Model/Layout/ConfigProcessor/Vue/VueSuggestionItemConfigProcessor.php
+++ b/Model/Layout/ConfigProcessor/Vue/VueSuggestionItemConfigProcessor.php
@@ -16,6 +16,9 @@ namespace HawkSearch\EsIndexing\Model\Layout\ConfigProcessor\Vue;
 
 class VueSuggestionItemConfigProcessor extends VueResultItemConfigProcessor
 {
+    /**
+     * @return array<string, mixed>
+     */
     public function process(array $jsConfig)
     {
         $jsConfig = parent::process($jsConfig);

--- a/Model/Layout/ConfigProcessor/Vue/VueTabConfigProcessor.php
+++ b/Model/Layout/ConfigProcessor/Vue/VueTabConfigProcessor.php
@@ -18,6 +18,9 @@ use HawkSearch\EsIndexing\Model\Layout\LayoutConfigProcessorInterface;
 
 class VueTabConfigProcessor implements LayoutConfigProcessorInterface
 {
+    /**
+     * @return array<string, mixed>
+     */
     public function process(array $jsConfig)
     {
         $jsConfig['tabConfig'] = [

--- a/Model/MessageQueue/BulkPublisher.php
+++ b/Model/MessageQueue/BulkPublisher.php
@@ -69,8 +69,7 @@ class BulkPublisher extends AbstractSimpleObject implements BulkPublisherInterfa
         MessageManagerInterface $messageManager,
         string $bulkDescription = null,
         array $data = []
-    )
-    {
+    ) {
         parent::__construct($data);
         $this->serializer = $serializer;
         $this->operationRepository = $operationRepository;
@@ -85,8 +84,9 @@ class BulkPublisher extends AbstractSimpleObject implements BulkPublisherInterfa
     }
 
     /**
-     * @throws LocalizedException
+     * @return void
      * @throws \Exception
+     * @throws LocalizedException
      */
     public function publish()
     {

--- a/Model/MessageQueue/MessageTopicByObjectResolver.php
+++ b/Model/MessageQueue/MessageTopicByObjectResolver.php
@@ -26,12 +26,14 @@ class MessageTopicByObjectResolver implements MessageTopicResolverInterface
     public function __construct(
         string $topic,
         string $resolverClass
-    )
-    {
+    ) {
         $this->topic = $topic;
         $this->resolverClass = $resolverClass;
     }
 
+    /**
+     * @return string
+     */
     public function resolve(object $object)
     {
         return $object instanceof $this->resolverClass ? $this->topic : '';

--- a/Model/MessageQueue/MessageTopicResolverComposite.php
+++ b/Model/MessageQueue/MessageTopicResolverComposite.php
@@ -33,6 +33,10 @@ class MessageTopicResolverComposite implements MessageTopicResolverInterface
         $this->resolvers = $resolvers;
     }
 
+    /**
+     * @return string
+     * @throws InputException
+     */
     public function resolve(object $object)
     {
         foreach ($this->resolvers as $resolver) {

--- a/Model/MessageQueue/RetryBulkManagement.php
+++ b/Model/MessageQueue/RetryBulkManagement.php
@@ -27,14 +27,15 @@ class RetryBulkManagement implements BulkManagementInterface
     public function __construct(
         OperationManagementInterface $operationManagement,
         BulkPublisherInterface $publisher
-    )
-    {
+    ) {
         $this->operationManagement = $operationManagement;
         $this->publisher = $publisher;
     }
 
     /**
      * It is used to reschedule bulk operations
+     *
+     * @return bool
      */
     public function scheduleBulk($bulkUuid, array $operations, $description, $userId = null)
     {
@@ -60,6 +61,7 @@ class RetryBulkManagement implements BulkManagementInterface
 
 
     /**
+     * @return bool
      * @throws \LogicException
      */
     public function deleteBulk($bulkId)

--- a/Model/MessageQueue/Validator/BulkAccessValidator.php
+++ b/Model/MessageQueue/Validator/BulkAccessValidator.php
@@ -27,16 +27,13 @@ class BulkAccessValidator
     public function __construct(
         OperationValidatorInterface $operationTopicValidator,
         BulkOperationsStatus $bulkOperationsStatus
-    )
-    {
+    ) {
         $this->operationTopicValidator = $operationTopicValidator;
         $this->bulkOperationsStatus = $bulkOperationsStatus;
     }
 
     /**
      * Check if content is allowed
-     *
-     * @return bool
      */
     public function isAllowed(string $bulkUuid): bool
     {

--- a/Model/MessageQueue/Validator/BulkAllOperationCompleteValidator.php
+++ b/Model/MessageQueue/Validator/BulkAllOperationCompleteValidator.php
@@ -23,14 +23,10 @@ class BulkAllOperationCompleteValidator implements OperationValidatorInterface
 
     public function __construct(
         BulkOperationManagement $bulkOperationManagement
-    )
-    {
+    ) {
         $this->bulkOperationManagement = $bulkOperationManagement;
     }
 
-    /**
-     * @return bool
-     */
     public function validate(OperationInterface $operation): bool
     {
         $allCount = $this->bulkOperationManagement->getOperationsByBulkUuid($operation->getBulkUuid())->getTotalCount();

--- a/Model/MessageQueue/Validator/OperationValidatorInterface.php
+++ b/Model/MessageQueue/Validator/OperationValidatorInterface.php
@@ -24,7 +24,6 @@ use Magento\Framework\Bulk\OperationInterface;
 interface OperationValidatorInterface
 {
     /**
-     * @return bool
      * @throws InvalidBulkOperationException
      */
     public function validate(OperationInterface $operation): bool;

--- a/Model/Product/EntityManager/Operation/ExtensionPool.php
+++ b/Model/Product/EntityManager/Operation/ExtensionPool.php
@@ -15,12 +15,16 @@ declare(strict_types=1);
 namespace HawkSearch\EsIndexing\Model\Product\EntityManager\Operation;
 
 use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Framework\EntityManager\Operation\ExtensionInterface;
 
 /**
  * Do not process extension attributes for ProductRepository used for collecting products for indexing
  */
 class ExtensionPool extends \Magento\Framework\EntityManager\Operation\ExtensionPool
 {
+    /**
+     * @return ExtensionInterface[]
+     */
     public function getActions($entityType, $actionName)
     {
         if ($entityType === ProductInterface::class && $actionName === 'read') {

--- a/Model/Product/Field/Handler/Category.php
+++ b/Model/Product/Field/Handler/Category.php
@@ -23,6 +23,9 @@ use Magento\Framework\DataObject;
  */
 class Category implements FieldHandlerInterface
 {
+    /**
+     * @return list<int>
+     */
     public function handle(DataObject $item, string $fieldName)
     {
         return $item->getCategoryIds();

--- a/Model/Product/Field/Handler/Composite.php
+++ b/Model/Product/Field/Handler/Composite.php
@@ -23,6 +23,7 @@ use Magento\Catalog\Model\Product as ProductModel;
 use Magento\Catalog\Model\ResourceModel\Eav\Attribute as AttributeResource;
 use Magento\Catalog\Model\ResourceModel\Product as ProductResource;
 use Magento\Framework\DataObject;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\ObjectManagerInterface;
 
 /**
@@ -51,13 +52,16 @@ class Composite extends FieldHandler\Composite
         ProductTypePoolInterface $productTypePool,
         ValueProcessorInterface $valueProcessor,
         array $handlers = []
-    )
-    {
+    ) {
         parent::__construct($objectManager, $handlers);
         $this->productTypePool = $productTypePool;
         $this->valueProcessor = $valueProcessor;
     }
 
+    /**
+     * @return list<mixed>
+     * @throws LocalizedException
+     */
     public function handle(DataObject $item, string $fieldName)
     {
         $value = $this->formatValue(parent::handle($item, $fieldName));

--- a/Model/Product/Field/Handler/DefaultHandler.php
+++ b/Model/Product/Field/Handler/DefaultHandler.php
@@ -33,12 +33,12 @@ class DefaultHandler implements FieldHandlerInterface
 
     public function __construct(
         ProductAttributesProvider $productAttributes = null
-    )
-    {
+    ) {
         $this->productAttributes = $productAttributes ?: ObjectManager::getInstance()->get(ProductAttributesProvider::class);
     }
 
     /**
+     * @return mixed
      * @throws LocalizedException
      */
     public function handle(DataObject $item, string $fieldName)

--- a/Model/Product/Field/Handler/ImageUrl.php
+++ b/Model/Product/Field/Handler/ImageUrl.php
@@ -44,8 +44,7 @@ class ImageUrl implements FieldHandlerInterface
         UrlHelper $urlHelper,
         AdvancedConfig $advancedConfig,
         StoreManagerInterface $storeManager
-    )
-    {
+    ) {
         $this->imageHelper = $imageHelper;
         $this->urlHelper = $urlHelper;
         $this->advancedConfig = $advancedConfig;
@@ -53,7 +52,7 @@ class ImageUrl implements FieldHandlerInterface
     }
 
     /**
-     * @throws NoSuchEntityException
+     * @return string
      */
     public function handle(DataObject $item, string $fieldName)
     {

--- a/Model/Product/Field/Handler/Url.php
+++ b/Model/Product/Field/Handler/Url.php
@@ -25,14 +25,16 @@ use Magento\Store\Model\StoreManagerInterface;
 class Url implements FieldHandlerInterface
 {
     private StoreManagerInterface $storeManager;
-    
+
     public function __construct(
         StoreManagerInterface $storeManager
-    )
-    {
+    ) {
         $this->storeManager = $storeManager;
     }
 
+    /**
+     * @return string
+     */
     public function handle(DataObject $item, string $fieldName)
     {
         /**

--- a/Model/Product/Field/Handler/VisibilityCatalog.php
+++ b/Model/Product/Field/Handler/VisibilityCatalog.php
@@ -25,14 +25,16 @@ use Magento\Framework\DataObject;
 class VisibilityCatalog implements FieldHandlerInterface
 {
     private Visibility $visibility;
-    
+
     public function __construct(
         Visibility $visibility
-    )
-    {
+    ) {
         $this->visibility = $visibility;
     }
 
+    /**
+     * @return bool
+     */
     public function handle(DataObject $item, string $fieldName)
     {
         return in_array($item->getVisibility(), $this->visibility->getVisibleInCatalogIds());

--- a/Model/Product/Field/Handler/VisibilitySearch.php
+++ b/Model/Product/Field/Handler/VisibilitySearch.php
@@ -25,14 +25,16 @@ use Magento\Framework\DataObject;
 class VisibilitySearch implements FieldHandlerInterface
 {
     private Visibility $visibility;
-    
+
     public function __construct(
         Visibility $visibility
-    )
-    {
+    ) {
         $this->visibility = $visibility;
     }
 
+    /**
+     * @return bool
+     */
     public function handle(DataObject $item, string $fieldName)
     {
         return in_array($item->getVisibility(), $this->visibility->getVisibleInSearchIds());

--- a/Model/Product/PriceManagement.php
+++ b/Model/Product/PriceManagement.php
@@ -35,11 +35,13 @@ class PriceManagement implements PriceManagementInterface
      */
     public function __construct(
         ProductTypePoolInterface $productTypePool
-    )
-    {
+    ) {
         $this->productTypePool = $productTypePool;
     }
 
+    /**
+     * @return void
+     */
     public function collectPrices(ProductInterface $product, array &$itemData)
     {
         $priceProvider = $this->productTypePool->get($product->getTypeId());

--- a/Model/Product/PriceManagementInterface.php
+++ b/Model/Product/PriceManagementInterface.php
@@ -10,6 +10,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+
 namespace HawkSearch\EsIndexing\Model\Product;
 
 
@@ -26,6 +27,7 @@ interface PriceManagementInterface
     /**
      * @param ProductInterface $product
      * @param PriceData $itemData
+     * @return void
      */
     public function collectPrices(ProductInterface $product, array &$itemData);
 }

--- a/Model/Product/ProductType/DefaultType.php
+++ b/Model/Product/ProductType/DefaultType.php
@@ -45,8 +45,7 @@ abstract class DefaultType implements ProductTypeInterface
         GroupManagementInterface $groupManagement,
         ModuleManager $moduleManager,
         PricingHelper $pricingHelper
-    )
-    {
+    ) {
         $this->priceCurrency = $priceCurrency;
         $this->customerGroupSource = $customerGroupSource;
         $this->groupManagement = $groupManagement;
@@ -134,6 +133,7 @@ abstract class DefaultType implements ProductTypeInterface
      * @param string $priceName
      * @param array<array-key, float|null> $prices
      * @param PriceData $priceData
+     * @return void
      */
     protected function addPricesFromArray(string $priceName, array $prices, array &$priceData)
     {
@@ -148,6 +148,7 @@ abstract class DefaultType implements ProductTypeInterface
     /**
      * @param ProductModel $product
      * @param PriceData $priceData
+     * @return void
      */
     protected function addPricesIncludingTax(ProductInterface $product, array &$priceData)
     {
@@ -160,6 +161,7 @@ abstract class DefaultType implements ProductTypeInterface
 
     /**
      * @param PriceData $priceData
+     * @return void
      * @todo Review if we need to push prices rounded to the index
      */
     protected function roundPrices(array &$priceData)
@@ -172,6 +174,7 @@ abstract class DefaultType implements ProductTypeInterface
     /**
      * @param ProductModel $product
      * @param PriceData $priceData
+     * @return void
      */
     protected function addFormattedPrices(ProductInterface $product, array &$priceData)
     {
@@ -208,6 +211,7 @@ abstract class DefaultType implements ProductTypeInterface
      * @param string $suffix
      * @param float $price
      * @param PriceData $priceData
+     * @return void
      */
     protected function addSuffixedValue(string $priceName, string $suffix, float $price, array &$priceData)
     {
@@ -296,7 +300,7 @@ abstract class DefaultType implements ProductTypeInterface
 
     /**
      * @param ProductModel $product
-     * @return array
+     * @return array<int, ?float>
      * @throws LocalizedException
      */
     protected function getTierPrices(ProductInterface $product): array

--- a/Model/SmartBar.php
+++ b/Model/SmartBar.php
@@ -19,7 +19,6 @@ use Magento\Framework\Api\AbstractSimpleObject;
 
 class SmartBar extends AbstractSimpleObject implements SmartBarInterface
 {
-
     public function getBoostAndBury(): bool
     {
         return !!$this->_get(self::FIELD_BOOST_AND_BURY);

--- a/Model/VariantOptions.php
+++ b/Model/VariantOptions.php
@@ -19,7 +19,6 @@ use Magento\Framework\Api\AbstractSimpleObject;
 
 class VariantOptions extends AbstractSimpleObject implements VariantOptionsInterface
 {
-
     public function getCountFacetHitOnChild(): bool
     {
         return !!$this->_get(self::FIELD_COUNT_FACET_HIT_ON_CHILD);

--- a/Plugin/AsynchronousOperationProcessorPlugin.php
+++ b/Plugin/AsynchronousOperationProcessorPlugin.php
@@ -59,8 +59,7 @@ class AsynchronousOperationProcessorPlugin
         Indexing\Context $indexingContext,
         Emulation $emulation,
         BulkOperationManagement $bulkOperationManagement
-    )
-    {
+    ) {
         $this->messageEncoder = $messageEncoder;
         $this->operationManagement = $operationManagement;
         $this->bulkAllOperationCompleteValidator = $bulkAllOperationCompleteValidator;
@@ -76,7 +75,7 @@ class AsynchronousOperationProcessorPlugin
     }
 
     /**
-     * @return array
+     * @return ?array
      * @throws LocalizedException
      */
     public function beforeProcess(OperationProcessor $subject, string $encodedMessage)

--- a/Registry/CurrentCategory.php
+++ b/Registry/CurrentCategory.php
@@ -40,6 +40,9 @@ class CurrentCategory
         return $this->category;
     }
 
+    /**
+     * @return void
+     */
     public function set(CategoryInterface $category)
     {
         $this->category = $category;

--- a/Service/DataStorage.php
+++ b/Service/DataStorage.php
@@ -44,6 +44,7 @@ class DataStorage implements DataStorageInterface
     }
 
     /**
+     * @return void
      * @throws RuntimeException
      */
     public function set(mixed $value, bool $graceful = false)
@@ -58,6 +59,9 @@ class DataStorage implements DataStorageInterface
         $this->value = $value;
     }
 
+    /**
+     * @return void
+     */
     public function reset()
     {
         if (isset($this->value)) {
@@ -70,6 +74,9 @@ class DataStorage implements DataStorageInterface
         }
     }
 
+    /**
+     * @return mixed
+     */
     public function get(bool $reset = false)
     {
         $value = null;

--- a/Ui/Component/DataProvider/BulkDataProvider.php
+++ b/Ui/Component/DataProvider/BulkDataProvider.php
@@ -21,6 +21,7 @@ class BulkDataProvider extends OperationDataProvider
 
     /**
      * @param array<string, mixed> $meta
+     * @return array
      */
     public function prepareMeta($meta)
     {

--- a/Ui/Component/DataProvider/Operation/SearchResult.php
+++ b/Ui/Component/DataProvider/Operation/SearchResult.php
@@ -50,8 +50,7 @@ class SearchResult extends SearchResultParent
         $mainTable = 'magento_operation',
         $resourceModel = null,
         $identifierName = 'id'
-    )
-    {
+    ) {
         $this->identifierResolver = $identifierResolver;
         parent::__construct(
             $entityFactory,
@@ -66,6 +65,9 @@ class SearchResult extends SearchResultParent
         );
     }
 
+    /**
+     * @return void
+     */
     protected function _initSelect()
     {
         $bulkUuid = $this->identifierResolver->execute();
@@ -74,9 +76,11 @@ class SearchResult extends SearchResultParent
             ->reset(Select::WHERE)
             ->from(['main_table' => $this->getMainTable()])
             ->where('bulk_uuid=?', $bulkUuid);
-        return $this;
     }
 
+    /**
+     * @return $this
+     */
     protected function _afterLoad()
     {
         parent::_afterLoad();

--- a/Ui/Component/Listing/Column/StartTime.php
+++ b/Ui/Component/Listing/Column/StartTime.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace HawkSearch\EsIndexing\Ui\Component\Listing\Column;
 
 use HawkSearch\EsIndexing\Model\ResourceModel\AsynchronousOperations\Operation as OperationResource;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Locale\Bundle\DataBundle;
 use Magento\Framework\Locale\ResolverInterface;
 use Magento\Framework\Stdlib\BooleanUtils;
@@ -49,8 +50,7 @@ class StartTime extends Date
         array $data = [],
         ResolverInterface $localeResolver = null,
         DataBundle $dataBundle = null
-    )
-    {
+    ) {
         $this->operationResource = $operation;
         parent::__construct(
             $context,
@@ -64,6 +64,10 @@ class StartTime extends Date
         );
     }
 
+    /**
+     * @return void
+     * @throws LocalizedException
+     */
     public function prepare()
     {
         parent::prepare();


### PR DESCRIPTION
| Q             | A
|---------------| ---
| Branch?       | 0.8
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| BC breaks?    | no
| Tests pass?   | yes
| Tickets       | HC-1703

This PR attempts to add `@return` annotartions on public/protected methods with the help of Symfony's `patch-type-declarations` script.
This is not a breaking change. The goal is to turn every `@return` phpDoc annotation to return type declaration on as many methods as possible on version 3.0