### PR TITLE
feat: add return types on internal/final/private methods

### DIFF
--- a/Api/Data/IndexItemsContextInterface.php
+++ b/Api/Data/IndexItemsContextInterface.php
@@ -36,7 +36,7 @@ interface IndexItemsContextInterface
      * @param string|null $value
      * @return $this
      */
-    public function setIndexName(?string $value);
+    public function setIndexName(?string $value): self;
 
     /**
      * @return IndexItemInterface[]
@@ -47,5 +47,5 @@ interface IndexItemsContextInterface
      * @param IndexItemInterface[]|null $value
      * @return $this
      */
-    public function setItems(?array $value);
+    public function setItems(?array $value): self;
 }

--- a/Api/LandingPageRepositoryInterface.php
+++ b/Api/LandingPageRepositoryInterface.php
@@ -10,22 +10,14 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+
 namespace HawkSearch\EsIndexing\Api;
 
 interface LandingPageRepositoryInterface
 {
-    /**
-     * @return mixed
-     */
-    public function getByUrl(string $url);
+    public function getByUrl(string $url): mixed;
 
-    /**
-     * @return mixed
-     */
-    public function get(int $id);
+    public function get(int $id): mixed;
 
-    /**
-     * @return mixed
-     */
-    public function getList();
+    public function getList(): mixed;
 }

--- a/Console/Command/RetryBulk.php
+++ b/Console/Command/RetryBulk.php
@@ -81,7 +81,7 @@ class RetryBulk extends Command
     /**
      * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $bulkUuid = $input->getArgument(self::INPUT_BULK_UUID);
         $statuses = $input->getArgument(self::INPUT_STATUSES);

--- a/Controller/LandingPage/View.php
+++ b/Controller/LandingPage/View.php
@@ -19,10 +19,8 @@ use HawkSearch\EsIndexing\Api\LandingPageManagementInterface;
 use Magento\Catalog\Model\CategoryFactory;
 use Magento\Catalog\Model\Session;
 use Magento\Framework\App\Action\Context;
-use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\Controller\ResultInterface;
 use Magento\Framework\Registry;
-use Magento\Framework\View\Result\Page;
 use Magento\Framework\View\Result\PageFactory;
 
 class View extends \Magento\Framework\App\Action\Action
@@ -42,8 +40,7 @@ class View extends \Magento\Framework\App\Action\Action
         PageFactory $resultPageFactory,
         LandingPageManagementInterface $landingPageManagement,
         LandingPageInterfaceFactory $landingPageInterfaceFactory
-    )
-    {
+    ) {
         parent::__construct($context);
         $this->resultPageFactory = $resultPageFactory;
         $this->session = $session;
@@ -54,11 +51,10 @@ class View extends \Magento\Framework\App\Action\Action
     }
 
     /**
-     * @return ResponseInterface|ResultInterface|Page
+     * @return ResultInterface
      */
-    public function execute()
+    public function execute(): ResultInterface
     {
-
         $category = $this->categoryFactory->create();
 
         //@TODO refactor this

--- a/Controller/LandingPageRouter.php
+++ b/Controller/LandingPageRouter.php
@@ -15,6 +15,7 @@ namespace HawkSearch\EsIndexing\Controller;
 
 use Magento\Framework\App\Action\Forward;
 use Magento\Framework\App\ActionFactory;
+use Magento\Framework\App\ActionInterface;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\App\RouterInterface;
 
@@ -24,15 +25,14 @@ class LandingPageRouter implements RouterInterface
 
     public function __construct(
         ActionFactory $actionFactory
-    )
-    {
+    ) {
         $this->actionFactory = $actionFactory;
     }
 
     /**
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    public function match(RequestInterface $request)
+    public function match(RequestInterface $request): ActionInterface
     {
         /*if (!$this->proxyConfigProvider->isLandingPageRouteEnabled()) {
             return false;

--- a/Model/Api/SearchCriteria/CollectionProcessor/CustomJoinProcessor.php
+++ b/Model/Api/SearchCriteria/CollectionProcessor/CustomJoinProcessor.php
@@ -38,8 +38,7 @@ class CustomJoinProcessor implements CollectionProcessorInterface
      */
     public function __construct(
         array $customJoins = []
-    )
-    {
+    ) {
         $this->joins = $customJoins;
     }
 
@@ -61,7 +60,7 @@ class CustomJoinProcessor implements CollectionProcessorInterface
     /**
      * @return void
      */
-    private function applyCustomJoin(string $joinName, AbstractDb $collection)
+    private function applyCustomJoin(string $joinName, AbstractDb $collection): void
     {
         $customJoin = $this->getCustomJoin($joinName);
 
@@ -75,7 +74,7 @@ class CustomJoinProcessor implements CollectionProcessorInterface
      * @return CustomJoinInterface|null
      * @throws \InvalidArgumentException
      */
-    private function getCustomJoin(string $joinName)
+    private function getCustomJoin(string $joinName): ?CustomJoinInterface
     {
         $joinType = null;
         if (isset($this->joins[$joinName])) {

--- a/Model/Field/Product/AttributeAdapter.php
+++ b/Model/Field/Product/AttributeAdapter.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 namespace HawkSearch\EsIndexing\Model\Field\Product;
 
 use Magento\Catalog\Api\Data\ProductAttributeInterface;
-use Magento\Framework\DataObject;
 
 /**
  * @internal experimental feature
@@ -28,36 +27,29 @@ class AttributeAdapter
     public function __construct(
         ProductAttributeInterface $attribute,
         string $attributeCode
-    )
-    {
+    ) {
         $this->attribute = $attribute;
         $this->attributeCode = $attributeCode;
     }
 
     /**
      * Get product attribute instance.
-     *
-     * @return ProductAttributeInterface|DataObject
      */
-    public function getAttribute()
+    public function getAttribute(): ProductAttributeInterface
     {
         return $this->attribute;
     }
 
     /**
      * Get product attribute code.
-     *
-     * @return string
      */
-    public function getAttributeCode()
+    public function getAttributeCode(): string
     {
         return $this->attributeCode;
     }
 
     /**
      * Check if attribute is searchable.
-     *
-     * @return bool
      */
     public function isSearchable(): bool
     {
@@ -66,8 +58,6 @@ class AttributeAdapter
 
     /**
      * Check if attribute is filterable.
-     *
-     * @return bool
      */
     public function isFilterable(): bool
     {
@@ -76,8 +66,6 @@ class AttributeAdapter
 
     /**
      * Check if attribute is sortable.
-     *
-     * @return bool
      */
     public function isSortable(): bool
     {

--- a/Model/Field/Product/AttributeFacade.php
+++ b/Model/Field/Product/AttributeFacade.php
@@ -23,10 +23,7 @@ class AttributeFacade
 {
     private AttributeAdapter $attribute;
 
-    /**
-     * @return void
-     */
-    public function execute(FieldInterface $field, AttributeAdapter $attribute)
+    public function execute(FieldInterface $field, AttributeAdapter $attribute): void
     {
         $this->attribute = $attribute;
 
@@ -35,46 +32,31 @@ class AttributeFacade
             ->processSortable($field);
     }
 
-    /**
-     * @return $this
-     */
-    protected function processSearchable(FieldInterface $field): AttributeFacade
+    private function processSearchable(FieldInterface $field): self
     {
         $this->setFieldSearchable($field, $this->attribute->isSearchable());
         return $this;
     }
 
-    /**
-     * @return $this
-     */
-    protected function processFilterable(FieldInterface $field): AttributeFacade
+    private function processFilterable(FieldInterface $field): self
     {
         $this->setFieldFilterable($field, $this->attribute->isFilterable());
         return $this;
     }
 
-    /**
-     * @return $this
-     */
-    protected function processSortable(FieldInterface $field): AttributeFacade
+    private function processSortable(FieldInterface $field): self
     {
         $this->setFieldSortable($field, $this->attribute->isSortable());
         return $this;
     }
 
-    /**
-     * @return bool
-     */
-    protected function isFieldSearchable(FieldInterface $field): bool
+    private function isFieldSearchable(FieldInterface $field): bool
     {
         return $field->getIsQuery()
             && in_array($field->getFieldType(), ['keyword', 'facet', 'text']);
     }
 
-    /**
-     * @return void
-     */
-    protected function setFieldSearchable(FieldInterface $field, bool $value)
+    private function setFieldSearchable(FieldInterface $field, bool $value): void
     {
         switch ($value) {
             case true:
@@ -90,18 +72,12 @@ class AttributeFacade
 
     }
 
-    /**
-     * @return bool
-     */
-    protected function isFieldFilterable(FieldInterface $field): bool
+    private function isFieldFilterable(FieldInterface $field): bool
     {
         return $field->getFieldType() === FieldInterface::FIELD_TYPE_FACET;
     }
 
-    /**
-     * @return void
-     */
-    protected function setFieldFilterable(FieldInterface $field, bool $value)
+    private function setFieldFilterable(FieldInterface $field, bool $value): void
     {
         switch ($value) {
             case true:
@@ -114,18 +90,12 @@ class AttributeFacade
         }
     }
 
-    /**
-     * @return bool
-     */
-    protected function isFieldSortable(FieldInterface $field): bool
+    private function isFieldSortable(FieldInterface $field): bool
     {
         return $field->getIsSort();
     }
 
-    /**
-     * @return void
-     */
-    protected function setFieldSortable(FieldInterface $field, bool $value)
+    private function setFieldSortable(FieldInterface $field, bool $value): void
     {
         $field->setIsSort($value);
     }

--- a/Model/Field/Product/AttributeProvider.php
+++ b/Model/Field/Product/AttributeProvider.php
@@ -41,10 +41,7 @@ class AttributeProvider
         $this->productAttributeFactory = $productAttributeFactory;
         $this->instanceName = $instanceName;
     }
-
-    /**
-     * @return AttributeAdapter
-     */
+    
     public function getByCode(string $attributeCode): AttributeAdapter
     {
         if (!isset($this->cachedAttributes[$attributeCode])) {

--- a/Model/IndexItemsContext.php
+++ b/Model/IndexItemsContext.php
@@ -27,7 +27,7 @@ class IndexItemsContext extends AbstractSimpleObject implements IndexItemsContex
         return (string)$this->_get(self::FIELD_INDEX_NAME);
     }
 
-    public function setIndexName(?string $value)
+    public function setIndexName(?string $value): IndexItemsContextInterface
     {
         return $this->setData(self::FIELD_INDEX_NAME, $value);
     }
@@ -44,7 +44,7 @@ class IndexItemsContext extends AbstractSimpleObject implements IndexItemsContex
         return $value;
     }
 
-    public function setItems(?array $value)
+    public function setItems(?array $value): IndexItemsContextInterface
     {
         return $this->setData(self::FIELD_ITEMS, $value);
     }

--- a/Model/IndexManagement.php
+++ b/Model/IndexManagement.php
@@ -210,7 +210,6 @@ class IndexManagement implements IndexManagementInterface
     /**
      * Get current index used for searching
      *
-     * @return string|null
      * @throws InstructionException
      * @throws NotFoundException
      * @throws NoSuchEntityException
@@ -231,12 +230,12 @@ class IndexManagement implements IndexManagementInterface
     }
 
     /**
-     * @return array
+     * @return list<string>
      * @throws InstructionException
      * @throws NotFoundException
      * @throws NoSuchEntityException
      */
-    private function getIndices()
+    private function getIndices(): array
     {
         if (empty($this->getIndicesFromCache())) {
             /** @var IndexListInterface $indexList */
@@ -248,7 +247,7 @@ class IndexManagement implements IndexManagementInterface
             }
         }
 
-        return $this->getIndicesFromCache();
+        return array_values($this->getIndicesFromCache());
     }
 
     /**
@@ -256,7 +255,7 @@ class IndexManagement implements IndexManagementInterface
      * @throws NoSuchEntityException
      * @throws NotFoundException
      */
-    private function setCurrentIndex(string $indexName)
+    private function setCurrentIndex(string $indexName): void
     {
         $data = [
             EsIndexInterface::INDEX_NAME => $indexName
@@ -273,7 +272,7 @@ class IndexManagement implements IndexManagementInterface
      * @throws NoSuchEntityException
      * @TODO Replace with \Psr\Cache\CacheItemPoolInterface implementation
      */
-    private function resetIndexCache()
+    private function resetIndexCache(): void
     {
         $storeId = $this->getStoreId();
         $this->indicesListCache[$storeId] = null;
@@ -284,7 +283,7 @@ class IndexManagement implements IndexManagementInterface
      * @throws NoSuchEntityException
      * @TODO Replace with {@see \Psr\Cache\CacheItemPoolInterface} implementation
      */
-    private function addIndexToCache(string $index, bool $isCurrent = false)
+    private function addIndexToCache(string $index, bool $isCurrent = false): void
     {
         $storeId = $this->getStoreId();
 
@@ -300,7 +299,7 @@ class IndexManagement implements IndexManagementInterface
      * @throws NoSuchEntityException
      * @TODO Replace with \Psr\Cache\CacheItemPoolInterface implementation
      */
-    private function removeIndexFromCache(string $index)
+    private function removeIndexFromCache(string $index): void
     {
         $storeId = $this->getStoreId();
 
@@ -311,17 +310,19 @@ class IndexManagement implements IndexManagementInterface
     }
 
     /**
-     * @return array
+     * @return list<string>
      * @throws NoSuchEntityException
      * @TODO Replace with \Psr\Cache\CacheItemPoolInterface implementation
      */
-    private function getIndicesFromCache(bool $isCurrent = false)
+    private function getIndicesFromCache(bool $isCurrent = false): array
     {
         $storeId = $this->getStoreId();
 
-        return $isCurrent
-            ? (array)($this->currentIndexCache[$storeId] ?? null)
-            : ($this->indicesListCache[$storeId] ?? []);
+        return array_values(
+            $isCurrent
+                ? (array)($this->currentIndexCache[$storeId] ?? null)
+                : ($this->indicesListCache[$storeId] ?? [])
+        );
     }
 
     /**

--- a/Model/Indexing/AbstractEntityRebuild.php
+++ b/Model/Indexing/AbstractEntityRebuild.php
@@ -375,7 +375,7 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
 
     /**
      * @param TItem $item
-     * @return array
+     * @return array<string, mixed>
      * @throws NotFoundException
      */
     private function processFields(DataObject $item): array
@@ -395,7 +395,7 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
      * Temporary method to overcome deprecation of getIndexedAttributes() method
      *
      * @param TItem $item
-     * @return array
+     * @return array<mixed>
      * @throws NotFoundException
      */
     private function processDeprecatedAttributes(DataObject $item): array
@@ -455,10 +455,9 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
     /**
      * @param TItem $item
      * @param string $fieldName
-     * @return mixed
      * @throws NotFoundException
      */
-    private function getFieldValue(DataObject $item, string $fieldName)
+    private function getFieldValue(DataObject $item, string $fieldName): mixed
     {
         $entityType = $this->getEntityType();
         if (method_exists($entityType, 'getFieldHandler')) {
@@ -473,10 +472,9 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
      *
      * @param TItem $item
      * @param string $attribute
-     * @return mixed
      * @throws NotFoundException
      */
-    private function getAttributeValueDeprecatedWrapper(DataObject $item, string $attribute)
+    private function getAttributeValueDeprecatedWrapper(DataObject $item, string $attribute): mixed
     {
         if ($this->isMethodOverwritten('getAttributeValue')) {
             $this->triggerDerivedMethodDeprecationMessage('getAttributeValue');
@@ -535,17 +533,11 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
         return $this->entityType;
     }
 
-    /**
-     * @return string
-     */
     private function getEntityIdField(): string
     {
         return '__uid';
     }
 
-    /**
-     * @return string
-     */
     private function getEntityTypeField(): string
     {
         return '__type';

--- a/Model/Indexing/Entity/Product/EntityRebuild.php
+++ b/Model/Indexing/Entity/Product/EntityRebuild.php
@@ -67,8 +67,7 @@ class EntityRebuild extends AbstractEntityRebuild
         StockRegistryInterface $stockRegistry,
         Product\Attributes $productAttributes,
         Product $productDataProvider
-    )
-    {
+    ) {
         parent::__construct(
             $entityTypePool,
             $eventManager,
@@ -86,9 +85,8 @@ class EntityRebuild extends AbstractEntityRebuild
 
     /**
      * @param ItemType $product
-     * @return bool
      */
-    private function isProductInStock(ProductModel $product)
+    private function isProductInStock(ProductModel $product): bool
     {
         $stockItem = $this->stockRegistry->getStockItem($product->getId());
 

--- a/Model/Indexing/Entity/Product/ItemsDataProvider.php
+++ b/Model/Indexing/Entity/Product/ItemsDataProvider.php
@@ -134,7 +134,6 @@ class ItemsDataProvider implements ItemsDataProviderInterface
 
     /**
      * @param ItemType[] $products
-     * @return void
      */
     private function addParentCategoriesToProducts(array $products): void
     {
@@ -177,10 +176,9 @@ class ItemsDataProvider implements ItemsDataProviderInterface
      * Add parent ids data to loaded items
      *
      * @param ItemType[] $products
-     * @return void
      * @throws Exception
      */
-    private function addParentIds(array $products)
+    private function addParentIds(array $products): void
     {
         $parentsMap = $this->productDataProvider->getParentsByChildMap(array_keys($products));
         foreach ($products as $item) {
@@ -194,10 +192,9 @@ class ItemsDataProvider implements ItemsDataProviderInterface
      * Load child products collection and add its data to loaded product items
      *
      * @param ItemType[] $products
-     * @return void
      * @throws Exception
      */
-    private function addChildProducts(array $products)
+    private function addChildProducts(array $products): void
     {
         if (!$products) {
             return;

--- a/Model/Indexing/EntityTypePool.php
+++ b/Model/Indexing/EntityTypePool.php
@@ -89,7 +89,7 @@ class EntityTypePool implements EntityTypePoolInterface
     /**
      * @return TMap<TKey, TValue>
      */
-    public function getList()
+    public function getList(): iterable
     {
         return $this->types;
     }

--- a/Model/Indexing/EntityTypePoolInterface.php
+++ b/Model/Indexing/EntityTypePoolInterface.php
@@ -38,7 +38,7 @@ interface EntityTypePoolInterface
      *
      * @return iterable<TValue>
      */
-    public function getList();
+    public function getList(): iterable;
 
     /**
      * Create not shared entity type instance by its type name

--- a/Model/LandingPageRepository.php
+++ b/Model/LandingPageRepository.php
@@ -33,28 +33,29 @@ class LandingPageRepository implements LandingPageRepositoryInterface
         StoreManagerInterface $storeManager,
         Cache $cache,
         SerializerInterface $serializer
-    )
-    {
+    ) {
         $this->storeManager = $storeManager;
         $this->cache = $cache;
         $this->serializer = $serializer;
     }
 
-    public function getByUrl(string $url)
+    public function getByUrl(string $url): mixed
     {
         // TODO: Implement getByUrl() method.
+        return null;
     }
 
-    public function get(int $id)
+    public function get(int $id): mixed
     {
         // TODO: Implement get() method.
+        return null;
     }
 
     /**
      * @TODO move pages storage resource to MySQL
      * @TODO do not call Hawk API in repository
      */
-    public function getList()
+    public function getList(): mixed
     {
         if (($serialized = $this->cache->load($this->getCacheKey()))) {
             $landingPages = $this->serializer->unserialize($serialized);
@@ -75,7 +76,7 @@ class LandingPageRepository implements LandingPageRepositoryInterface
      * @TODO move pages storage resource to MySQL
      * @throws NoSuchEntityException
      */
-    private function getCacheKey()
+    private function getCacheKey(): string
     {
         return self::CACHE_KEY . $this->storeManager->getStore()->getId();
     }

--- a/Model/MessageQueue/Consumer.php
+++ b/Model/MessageQueue/Consumer.php
@@ -17,6 +17,7 @@ namespace HawkSearch\EsIndexing\Model\MessageQueue;
 
 use HawkSearch\EsIndexing\Api\Data\QueueOperationDataInterface;
 use HawkSearch\EsIndexing\Helper\ObjectHelper;
+use Magento\Framework\Api\SearchCriteria;
 use Magento\Framework\Data\ObjectFactory;
 use Magento\Framework\DataObject;
 use Magento\Framework\Serialize\SerializerInterface;
@@ -35,8 +36,7 @@ class Consumer
         SerializerInterface $serializer,
         ObjectFactory $objectFactory,
         ObjectHelper $objectHelper
-    )
-    {
+    ) {
         $this->serializer = $serializer;
         $this->objectFactory = $objectFactory;
         $this->objectHelper = $objectHelper;
@@ -67,9 +67,11 @@ class Consumer
     }
 
     /**
-     * @return array
+     * @return array{
+     *     searchCriteria: SearchCriteria
+     * }
      */
-    private function buildArguments(DataObject $data)
+    private function buildArguments(DataObject $data): array
     {
         $arguments = $data->getData('method_arguments') ?? [];
         foreach ($arguments as $paramName => $value) {

--- a/Model/MessageQueue/MessageManager.php
+++ b/Model/MessageQueue/MessageManager.php
@@ -100,9 +100,9 @@ class MessageManager extends AbstractSimpleObject implements MessageManagerInter
      * Set other operation global data
      *
      * @param MessageType $messageData
-     * @return array
+     * @return MessageType
      */
-    private function updateApplicationHeaders(array $messageData)
+    private function updateApplicationHeaders(array $messageData): array
     {
         try {
             $storeId = $this->storeManager->getStore()->getId();

--- a/Model/MessageQueue/RetryBulkManagement.php
+++ b/Model/MessageQueue/RetryBulkManagement.php
@@ -75,7 +75,7 @@ class RetryBulkManagement implements BulkManagementInterface
      * @param OperationInterface[] $operations
      * @return void
      */
-    private function publishOperations(array $operations)
+    private function publishOperations(array $operations): void
     {
         $operationsByTopics = [];
         foreach ($operations as $operation) {

--- a/Model/MessageQueue/Validator/BulkAccessValidator.php
+++ b/Model/MessageQueue/Validator/BulkAccessValidator.php
@@ -50,9 +50,6 @@ class BulkAccessValidator
         return $isAllowed;
     }
 
-    /**
-     * @return bool
-     */
     private function isTopicAllowed(OperationInterface $operation): bool
     {
         $isAllowed = true;

--- a/Model/Product/Attribute/ValueProcessor.php
+++ b/Model/Product/Attribute/ValueProcessor.php
@@ -31,7 +31,7 @@ class ValueProcessor implements ValueProcessorInterface
         'status'
     ];
 
-    public function process(Attribute $attribute, array $value, array $relatedValues = [])
+    public function process(Attribute $attribute, array $value, array $relatedValues = []): array
     {
         if ($this->isRollUpAttributeStrategy($attribute)) {
             $value = array_merge($value, $relatedValues);
@@ -43,21 +43,15 @@ class ValueProcessor implements ValueProcessorInterface
 
         return $value;
     }
-
-    /**
-     * @return bool
-     */
-    protected function isRollUpAttributeStrategy(Attribute $attribute)
+    
+    private function isRollUpAttributeStrategy(Attribute $attribute): bool
     {
         $isStatic = $attribute->getBackendType() === 'static';
         $isSystemAttribute = in_array($attribute->getAttributeCode(), self::SYSTEM_ATTRIBUTES);
         return !$isStatic && !$isSystemAttribute;
     }
 
-    /**
-     * @return bool
-     */
-    protected function isUniqueValueStrategy(Attribute $attribute)
+    private function isUniqueValueStrategy(Attribute $attribute): bool
     {
         return true;
     }

--- a/Model/Product/Attribute/ValueProcessorInterface.php
+++ b/Model/Product/Attribute/ValueProcessorInterface.php
@@ -25,7 +25,7 @@ interface ValueProcessorInterface
      * @param Attribute $attribute
      * @param list<mixed> $value
      * @param list<mixed> $relatedValues
-     * @return array
+     * @return list<mixed>
      */
-    public function process(Attribute $attribute, array $value, array $relatedValues = []);
+    public function process(Attribute $attribute, array $value, array $relatedValues = []): array;
 }

--- a/Model/Product/EntityPriceObserver.php
+++ b/Model/Product/EntityPriceObserver.php
@@ -26,15 +26,14 @@ class EntityPriceObserver implements ObserverInterface
 
     public function __construct(
         PriceManagementInterface $priceManagement
-    )
-    {
+    ) {
         $this->priceManagement = $priceManagement;
     }
 
     /**
      * Add product entity pricing data to the index data
      */
-    public function execute(Observer $observer)
+    public function execute(Observer $observer): void
     {
         /** @var DataObject $itemData */
         $itemData = $observer->getData('item_data');
@@ -42,13 +41,11 @@ class EntityPriceObserver implements ObserverInterface
         $product = $observer->getData('item');
 
         if (!$product instanceof ProductInterface) {
-            return $this;
+            return;
         }
 
         $priceInfo = [];
         $this->priceManagement->collectPrices($product, $priceInfo);
         $itemData->addData($priceInfo);
-
-        return $this;
     }
 }

--- a/Model/Product/Field/Handler/Composite.php
+++ b/Model/Product/Field/Handler/Composite.php
@@ -86,9 +86,9 @@ class Composite extends FieldHandler\Composite
     /**
      * Safely apply values of array type.
      *
-     * @return array
+     * @return list<mixed>
      */
-    private function formatValue(mixed $value)
+    private function formatValue(mixed $value): array
     {
         $result = [];
         if (is_array($value)) {

--- a/Model/Product/Field/Handler/DefaultHandler.php
+++ b/Model/Product/Field/Handler/DefaultHandler.php
@@ -71,9 +71,8 @@ class DefaultHandler implements FieldHandlerInterface
     /**
      * @param ItemType $product
      * @param AttributeResource $attribute
-     * @return mixed
      */
-    private function getProductAttributeText(ProductModel $product, AttributeResource $attribute)
+    private function getProductAttributeText(ProductModel $product, AttributeResource $attribute): mixed
     {
         $value = $product->getData($attribute->getAttributeCode());
         $valueText = null;

--- a/Model/Product/Field/Handler/ImageUrl.php
+++ b/Model/Product/Field/Handler/ImageUrl.php
@@ -67,10 +67,9 @@ class ImageUrl implements FieldHandlerInterface
     /**
      * @param ItemType $product
      * @param string $imageId
-     * @return string
      * @throws NoSuchEntityException
      */
-    private function getImageIdUrl(ProductModel $product, string $imageId)
+    private function getImageIdUrl(ProductModel $product, string $imageId): string
     {
         $imageUrl = $this->imageHelper->init($product, $imageId)->getUrl();
         $uri = $this->urlHelper->getUriInstance($imageUrl);

--- a/Model/Product/ProductType/DefaultType.php
+++ b/Model/Product/ProductType/DefaultType.php
@@ -221,7 +221,7 @@ abstract class DefaultType implements ProductTypeInterface
     /**
      * @return array<string, float>
      */
-    private function getSuffixedPrice(string $priceName, string $suffix, float $price)
+    private function getSuffixedPrice(string $priceName, string $suffix, float $price): array
     {
         return [$priceName . '_' . $suffix => $price];
     }

--- a/Observer/Indexer/InitializeFullReindexing.php
+++ b/Observer/Indexer/InitializeFullReindexing.php
@@ -27,15 +27,14 @@ class InitializeFullReindexing implements ObserverInterface
 
     public function __construct(
         IndexManagementInterface $indexManagement
-    )
-    {
+    ) {
         $this->indexManagement = $indexManagement;
     }
 
     /**
      * Perform actions related to full reindexing initialization
      */
-    public function execute(Observer $observer)
+    public function execute(Observer $observer): void
     {
         /** @var MessageManagerInterface $messageManager */
         $messageManager = $observer->getData('message_manager');

--- a/Observer/InitCurrentCategoryObserver.php
+++ b/Observer/InitCurrentCategoryObserver.php
@@ -26,8 +26,8 @@ class InitCurrentCategoryObserver implements ObserverInterface
     {
         $this->currentCategory = $currentCategory;
     }
-
-    public function execute(Observer $observer)
+    
+    public function execute(Observer $observer): void
     {
         /** @var CategoryInterface $category */
         $category = $observer->getEvent()->getData('category');

--- a/Observer/LayoutUpdateHandler.php
+++ b/Observer/LayoutUpdateHandler.php
@@ -28,13 +28,12 @@ class LayoutUpdateHandler implements ObserverInterface
     public function __construct(
         SearchConfig $searchConfig,
         CatalogHelper $catalogHelper
-    )
-    {
+    ) {
         $this->searchConfig = $searchConfig;
         $this->catalogHelper = $catalogHelper;
     }
 
-    public function execute(Observer $observer)
+    public function execute(Observer $observer): void
     {
         /** @var Layout $layout */
         $layout = $observer->getData('layout');
@@ -50,9 +49,6 @@ class LayoutUpdateHandler implements ObserverInterface
         $layout->getUpdate()->addHandle($handles);
     }
 
-    /**
-     * @return array
-     */
     private function getResultsHandles(string $action): array
     {
         $allowedActions = [
@@ -81,10 +77,7 @@ class LayoutUpdateHandler implements ObserverInterface
 
         return $handles;
     }
-
-    /**
-     * @return bool
-     */
+    
     private function isCategoriesEnabled(): bool
     {
         //@todo replace with \HawkSearch\EsIndexing\Registry\CurrentCategory::get()

--- a/Observer/SendCookieOnCartCompleteObserver.php
+++ b/Observer/SendCookieOnCartCompleteObserver.php
@@ -67,7 +67,7 @@ class SendCookieOnCartCompleteObserver implements ObserverInterface
         $this->jsonSerializer = $jsonSerializer;
     }
 
-    public function execute(Observer $observer)
+    public function execute(Observer $observer): void
     {
         if (!$this->eventTrackingConfig->isEnabled() || $this->httpRequest->isXmlHttpRequest()) {
             return;
@@ -84,9 +84,13 @@ class SendCookieOnCartCompleteObserver implements ObserverInterface
     }
 
     /**
-     * @return array
+     * @return array{
+     *     uniqueId: string,
+     *     itemPrice: float,
+     *     quantity: float
+     * }
      */
-    protected function formatCartItem(QuoteItem $item)
+    private function formatCartItem(QuoteItem $item): array
     {
         return [
             'uniqueId' => $this->productEntityType->getUniqueId($item->getProductId()),
@@ -98,12 +102,11 @@ class SendCookieOnCartCompleteObserver implements ObserverInterface
     /**
      * @param string $cookieName
      * @param QuoteItem[] $cartItems
-     * @return void
      * @throws InputException
      * @throws CookieSizeLimitReachedException
      * @throws FailureToSendException
      */
-    protected function setCookieForCartItems(string $cookieName, array $cartItems)
+    private function setCookieForCartItems(string $cookieName, array $cartItems): void
     {
         if (!empty($cartItems)) {
             $cartItems = array_map([$this, 'formatCartItem'], $cartItems);
@@ -114,11 +117,8 @@ class SendCookieOnCartCompleteObserver implements ObserverInterface
             );
         }
     }
-
-    /**
-     * @return PublicCookieMetadata
-     */
-    private function getCookieMetaData()
+    
+    private function getCookieMetaData(): PublicCookieMetadata
     {
         if (!isset($this->cookieMetadata)) {
             $this->cookieMetadata = $this->cookieMetadataFactory->createPublicCookieMetadata()

--- a/Observer/TrackSaleEventOnOrderSuccessObserver.php
+++ b/Observer/TrackSaleEventOnOrderSuccessObserver.php
@@ -28,13 +28,12 @@ class TrackSaleEventOnOrderSuccessObserver implements ObserverInterface
     public function __construct(
         EventTracking $eventTrackingConfig,
         LayoutInterface $layout
-    )
-    {
+    ) {
         $this->eventTrackingConfig = $eventTrackingConfig;
         $this->layout = $layout;
     }
 
-    public function execute(Observer $observer)
+    public function execute(Observer $observer): void
     {
         if (!$this->eventTrackingConfig->isEnabled()) {
             return;

--- a/Plugin/AsynchronousOperationProcessorPlugin.php
+++ b/Plugin/AsynchronousOperationProcessorPlugin.php
@@ -75,10 +75,10 @@ class AsynchronousOperationProcessorPlugin
     }
 
     /**
-     * @return ?array
+     * @return ?list<string>
      * @throws LocalizedException
      */
-    public function beforeProcess(OperationProcessor $subject, string $encodedMessage)
+    public function beforeProcess(OperationProcessor $subject, string $encodedMessage): ?array
     {
         /** @todo Mark operation as started */
         /** @var OperationInterface $operation */
@@ -100,12 +100,11 @@ class AsynchronousOperationProcessorPlugin
      * @param OperationProcessor $subject
      * @param null $result
      * @param string $encodedMessage
-     * @return void
      * @throws LocalizedException
      * @noinspection PhpMissingParamTypeInspection
      * @phpstan-ignore missingType.parameter
      */
-    public function afterProcess(OperationProcessor $subject, $result, string $encodedMessage)
+    public function afterProcess(OperationProcessor $subject, $result, string $encodedMessage): void
     {
         /** @var OperationInterface $operation */
         $operation = $this->messageEncoder->decode(AsyncConfig::SYSTEM_TOPIC_NAME, $encodedMessage);
@@ -128,10 +127,9 @@ class AsynchronousOperationProcessorPlugin
     /**
      * Finalize full reindexing process: rebuild hierarchy, set current index
      *
-     * @return void
      * @throws NoSuchEntityException|InvalidBulkOperationException
      */
-    private function finalizeFullReindexing(OperationInterface $operation)
+    private function finalizeFullReindexing(OperationInterface $operation): void
     {
         if (!$this->indexingContext->isFullReindex()) {
             return;
@@ -167,9 +165,6 @@ class AsynchronousOperationProcessorPlugin
         }
     }
 
-    /**
-     * @return bool
-     */
     private function isAllowed(OperationInterface $operation): bool
     {
         $isAllowed = true;
@@ -184,10 +179,8 @@ class AsynchronousOperationProcessorPlugin
 
     /**
      * Update operation status from magento_operation table
-     *
-     * @return void
      */
-    private function updateOperationStatus(OperationInterface $operation)
+    private function updateOperationStatus(OperationInterface $operation): void
     {
         try {
             $loadedOperation = $this->bulkOperationManagement->getOperationByBulkAndKey(

--- a/Plugin/Category/CategoryPlugin.php
+++ b/Plugin/Category/CategoryPlugin.php
@@ -28,8 +28,7 @@ class CategoryPlugin
 
     public function __construct(
         IndexerRegistry $indexerRegistry
-    )
-    {
+    ) {
         $this->categoryIndexer = $indexerRegistry->get(CategoryIndexer::INDEXER_ID);
         $this->productIndexer = $indexerRegistry->get(ProductIndexer::INDEXER_ID);
     }
@@ -37,20 +36,24 @@ class CategoryPlugin
     /**
      * Reindex on page save.
      *
-     * @return CategoryResource
      * @throws \Exception
      */
-    public function aroundSave(CategoryResource $categoryResource, \Closure $proceed, CategoryModel $object)
-    {
+    public function aroundSave(
+        CategoryResource $categoryResource,
+        \Closure $proceed,
+        CategoryModel $object
+    ): CategoryResource {
         return $this->addCommitCallback($categoryResource, $proceed, $object);
     }
 
     /**
-     * @return CategoryResource
      * @throws \Exception
      */
-    public function aroundDelete(CategoryResource $categoryResource, \Closure $proceed, CategoryModel $object)
-    {
+    public function aroundDelete(
+        CategoryResource $categoryResource,
+        \Closure $proceed,
+        CategoryModel $object
+    ): CategoryResource {
         $object->setAffectedProductIds(array_keys($object->getProductsPosition()));
         return $this->addCommitCallback($categoryResource, $proceed, $object);
     }
@@ -58,11 +61,13 @@ class CategoryPlugin
     /**
      * Reindex catalog search.
      *
-     * @return CategoryResource
      * @throws \Exception
      */
-    private function addCommitCallback(CategoryResource $categoryResource, \Closure $proceed, CategoryModel $category)
-    {
+    private function addCommitCallback(
+        CategoryResource $categoryResource,
+        \Closure $proceed,
+        CategoryModel $category
+    ): CategoryResource {
         try {
             $categoryResource->beginTransaction();
             $result = $proceed($category);
@@ -84,10 +89,8 @@ class CategoryPlugin
 
     /**
      * Reindex category if indexer is not scheduled
-     *
-     * @return void
      */
-    protected function reindexCategoryRow(int $pageId)
+    private function reindexCategoryRow(int $pageId): void
     {
         if (!$this->categoryIndexer->isScheduled()) {
             $this->categoryIndexer->reindexRow($pageId);
@@ -98,9 +101,8 @@ class CategoryPlugin
      * Reindex products if indexer is not scheduled
      *
      * @param int[] $productIds
-     * @return void
      */
-    protected function reindexProductList(array $productIds)
+    private function reindexProductList(array $productIds): void
     {
         if (!$this->productIndexer->isScheduled()) {
             $this->productIndexer->reindexList($productIds);

--- a/Plugin/Checkout/CustomerData/Cart.php
+++ b/Plugin/Checkout/CustomerData/Cart.php
@@ -41,7 +41,7 @@ class Cart
      * @throws NoSuchEntityException
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function afterGetSectionData(CustomerDataCart $subject, array $result)
+    public function afterGetSectionData(CustomerDataCart $subject, array $result): array
     {
         $items = $this->getQuote()->getAllVisibleItems();
         if (is_array($result['items'])) {
@@ -77,10 +77,10 @@ class Cart
      *
      * @param int $id
      * @param QuoteItem[] $itemsHaystack
-     * @return QuoteItem | bool
+     * @return QuoteItem | null
      * @todo make private
      */
-    protected function findItemById(int $id, array $itemsHaystack)
+    private function findItemById(int $id, array $itemsHaystack): ?QuoteItem
     {
         foreach ($itemsHaystack as $item) {
             /** @var QuoteItem $item */
@@ -89,6 +89,6 @@ class Cart
             }
         }
 
-        return false;
+        return null;
     }
 }

--- a/Plugin/ConsumerProcessorPlugin.php
+++ b/Plugin/ConsumerProcessorPlugin.php
@@ -36,8 +36,7 @@ class ConsumerProcessorPlugin
         StoreManagerInterface $storeManager,
         ContextInterface $indexingContext,
         Emulation $emulation
-    )
-    {
+    ) {
         $this->serializer = $serializer;
         $this->storeManager = $storeManager;
         $this->indexingContext = $indexingContext;
@@ -45,11 +44,10 @@ class ConsumerProcessorPlugin
     }
 
     /**
-     * @return null
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function beforeProcess(Consumer $subject, QueueOperationDataInterface $operation)
+    public function beforeProcess(Consumer $subject, QueueOperationDataInterface $operation): void
     {
         $data = $this->serializer->unserialize($operation->getData());
 
@@ -68,7 +66,5 @@ class ConsumerProcessorPlugin
 
         $isFullReindex = $applicationHeaders['full_reindex'] ?? false;
         $this->indexingContext->setIsFullReindex($isFullReindex);
-
-        return null;
     }
 }

--- a/Plugin/ImportExport/ImportPlugin.php
+++ b/Plugin/ImportExport/ImportPlugin.php
@@ -22,21 +22,19 @@ use Magento\ImportExport\Model\Import;
 class ImportPlugin
 {
     private IndexerInterface $productIndexer;
-    
+
     public function __construct(
         IndexerRegistry $indexerRegistry
-    )
-    {
+    ) {
         $this->productIndexer = $indexerRegistry->get(ProductIndexer::INDEXER_ID);
     }
 
     /**
      * Invalidate index after import
      *
-     * @return bool
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function afterImportSource(Import $subject, mixed $import)
+    public function afterImportSource(Import $subject, mixed $import): mixed
     {
         if (!$this->productIndexer->isScheduled()) {
             $this->productIndexer->invalidate();

--- a/Plugin/Indexing/Entity/Product/EntityRebuildPlugin.php
+++ b/Plugin/Indexing/Entity/Product/EntityRebuildPlugin.php
@@ -22,17 +22,14 @@ class EntityRebuildPlugin
 
     public function __construct(
         StockRegistryStorage $stockRegistryStorage
-    )
-    {
+    ) {
         $this->stockRegistryStorage = $stockRegistryStorage;
     }
 
     /**
      * Clean shared objects data
-     *
-     * @return void
      */
-    public function afterRebuild()
+    public function afterRebuild(): void
     {
         $this->stockRegistryStorage->clean();
     }

--- a/Plugin/Mview/View/StagingSubscriptionPlugin.php
+++ b/Plugin/Mview/View/StagingSubscriptionPlugin.php
@@ -33,16 +33,14 @@ class StagingSubscriptionPlugin
 
     public function __construct(
         TriggerFactory $triggerFactory
-    )
-    {
+    ) {
         $this->triggerFactory = $triggerFactory;
     }
 
     /**
-     * @return array|null
      * @throws \Zend_Db_Exception
      */
-    public function beforeSaveTrigger(Subscription $subject, Trigger $trigger)
+    public function beforeSaveTrigger(Subscription $subject, Trigger $trigger): ?array
     {
         if (!array_key_exists($subject->getView()->getId(), $this->allowedViewTables)) {
             return null;

--- a/Plugin/Page/PagePlugin.php
+++ b/Plugin/Page/PagePlugin.php
@@ -23,21 +23,19 @@ use Magento\Framework\Model\AbstractModel;
 class PagePlugin
 {
     private IndexerInterface $pageIndexer;
-    
+
     public function __construct(
         IndexerRegistry $indexerRegistry
-    )
-    {
+    ) {
         $this->pageIndexer = $indexerRegistry->get(ContentPageIndexer::INDEXER_ID);
     }
 
     /**
      * Reindex on page save.
      *
-     * @return PageResource
      * @throws \Exception
      */
-    public function aroundSave(PageResource $pageResource, \Closure $proceed, AbstractModel $object)
+    public function aroundSave(PageResource $pageResource, \Closure $proceed, AbstractModel $object): PageResource
     {
         return $this->addCommitCallback($pageResource, $proceed, $object);
     }
@@ -45,10 +43,9 @@ class PagePlugin
     /**
      * Reindex on product delete
      *
-     * @return PageResource
      * @throws \Exception
      */
-    public function aroundDelete(PageResource $pageResource, \Closure $proceed, AbstractModel $object)
+    public function aroundDelete(PageResource $pageResource, \Closure $proceed, AbstractModel $object): PageResource
     {
         return $this->addCommitCallback($pageResource, $proceed, $object);
     }
@@ -56,11 +53,13 @@ class PagePlugin
     /**
      * Reindex catalog search.
      *
-     * @return PageResource
      * @throws \Exception
      */
-    private function addCommitCallback(PageResource $pageResource, \Closure $proceed, AbstractModel $object)
-    {
+    private function addCommitCallback(
+        PageResource $pageResource,
+        \Closure $proceed,
+        AbstractModel $object
+    ): PageResource {
         try {
             $pageResource->beginTransaction();
             $result = $proceed($object);
@@ -78,10 +77,8 @@ class PagePlugin
 
     /**
      * Reindex page if indexer is not scheduled
-     *
-     * @return void
      */
-    private function reindexRow(int $pageId)
+    private function reindexRow(int $pageId): void
     {
         if (!$this->pageIndexer->isScheduled()) {
             $this->pageIndexer->reindexRow($pageId);

--- a/Plugin/Product/AbstractPlugin.php
+++ b/Plugin/Product/AbstractPlugin.php
@@ -21,20 +21,17 @@ use Magento\Framework\Indexer\IndexerRegistry;
 abstract class AbstractPlugin
 {
     private IndexerInterface $productIndexer;
-    
+
     public function __construct(
         IndexerRegistry $indexerRegistry
-    )
-    {
+    ) {
         $this->productIndexer = $indexerRegistry->get(ProductIndexer::INDEXER_ID);
     }
 
     /**
      * Reindex product if indexer is not scheduled
-     *
-     * @return void
      */
-    protected function reindexRow(int $productId)
+    protected function reindexRow(int $productId): void
     {
         if (!$this->productIndexer->isScheduled()) {
             $this->productIndexer->reindexRow($productId);
@@ -45,9 +42,8 @@ abstract class AbstractPlugin
      * Reindex product if indexer is not scheduled
      *
      * @param int[] $productIds
-     * @return void
      */
-    protected function reindexList(array $productIds)
+    protected function reindexList(array $productIds): void
     {
         if (!$this->productIndexer->isScheduled()) {
             $this->productIndexer->reindexList($productIds);

--- a/Plugin/Product/Product/ActionPlugin.php
+++ b/Plugin/Product/Product/ActionPlugin.php
@@ -25,7 +25,6 @@ class ActionPlugin extends AbstractPlugin
      * @param ProductAction $subject
      * @param ProductAction $action
      * @param array<int> $productIds
-     * @return ProductAction
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @noinspection PhpUnusedParameterInspection
      */
@@ -33,8 +32,7 @@ class ActionPlugin extends AbstractPlugin
         ProductAction $subject,
         ProductAction $action,
         array $productIds
-    )
-    {
+    ): ProductAction {
         $this->reindexList(array_unique($productIds));
 
         return $action;
@@ -46,10 +44,9 @@ class ActionPlugin extends AbstractPlugin
      * @param ProductAction $subject
      * @param null $result
      * @param list<int> $productIds
-     * @return void
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function afterUpdateWebsites(ProductAction $subject, $result, array $productIds)
+    public function afterUpdateWebsites(ProductAction $subject, $result, array $productIds): void
     {
         $this->reindexList(array_unique($productIds));
     }

--- a/Plugin/Product/Product/AttributePlugin.php
+++ b/Plugin/Product/Product/AttributePlugin.php
@@ -32,8 +32,7 @@ class AttributePlugin extends AbstractPlugin
     public function __construct(
         IndexerRegistry $indexerRegistry,
         Attributes $productAttributes
-    )
-    {
+    ) {
         parent::__construct($indexerRegistry);
         $this->productIndexer = $indexerRegistry->get(ProductIndexer::INDEXER_ID);
         $this->productAttributes = $productAttributes;
@@ -44,28 +43,24 @@ class AttributePlugin extends AbstractPlugin
      *
      * @param AttributeResourceModel $subject
      * @param Attribute $attribute
-     * @return void
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function beforeDelete(
         AttributeResourceModel $subject,
         AbstractModel $attribute
-    )
-    {
+    ): void {
         $this->isInvalidationNeeded = $this->isIndexInvalidationNeeded($attribute);
     }
 
     /**
      * Invalidate product indexer on attribute delete
      *
-     * @return AttributeResourceModel
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function afterDelete(
         AttributeResourceModel $subject,
         AttributeResourceModel $result
-    )
-    {
+    ): AttributeResourceModel {
         if ($this->isInvalidationNeeded) {
             $this->productIndexer->invalidate();
         }
@@ -80,7 +75,6 @@ class AttributePlugin extends AbstractPlugin
      * becasue new attributes should be added to indexed attributes list first
      *
      * @param Attribute $attribute
-     * @return bool
      */
     private function isIndexInvalidationNeeded(AbstractModel $attribute): bool
     {

--- a/Plugin/Product/ProductPlugin.php
+++ b/Plugin/Product/ProductPlugin.php
@@ -29,8 +29,7 @@ class ProductPlugin extends AbstractPlugin
     public function __construct(
         IndexerRegistry $indexerRegistry,
         ProductDataProvider $productDataProvider
-    )
-    {
+    ) {
         parent::__construct($indexerRegistry);
         $this->categoryIndexer = $indexerRegistry->get(CategoryIndexer::INDEXER_ID);
         $this->productDataProvider = $productDataProvider;
@@ -39,22 +38,26 @@ class ProductPlugin extends AbstractPlugin
     /**
      * Reindex on product save.
      *
-     * @return ProductResource
      * @throws \Exception
      */
-    public function aroundSave(ProductResource $productResource, \Closure $proceed, AbstractModel $object)
-    {
+    public function aroundSave(
+        ProductResource $productResource,
+        \Closure $proceed,
+        AbstractModel $object
+    ): ProductResource {
         return $this->addCommitCallback($productResource, $proceed, $object);
     }
 
     /**
      * Reindex on product delete
      *
-     * @return ProductResource
      * @throws \Exception
      */
-    public function aroundDelete(ProductResource $productResource, \Closure $proceed, AbstractModel $object)
-    {
+    public function aroundDelete(
+        ProductResource $productResource,
+        \Closure $proceed,
+        AbstractModel $object
+    ): ProductResource {
         $object->setAffectedCategoryIds($object->getCategoryIds());
         $object->setAffectedParentProductIds($this->productDataProvider->getParentProductIds([$object->getId()]));
         return $this->addCommitCallback($productResource, $proceed, $object);
@@ -63,11 +66,13 @@ class ProductPlugin extends AbstractPlugin
     /**
      * Reindex catalog search.
      *
-     * @return ProductResource
      * @throws \Exception
      */
-    private function addCommitCallback(ProductResource $productResource, \Closure $proceed, AbstractModel $object)
-    {
+    private function addCommitCallback(
+        ProductResource $productResource,
+        \Closure $proceed,
+        AbstractModel $object
+    ): ProductResource {
         try {
             $productResource->beginTransaction();
             $result = $proceed($object);
@@ -93,9 +98,8 @@ class ProductPlugin extends AbstractPlugin
      * Reindex categories if indexer is not scheduled
      *
      * @param int[] $categoryIds
-     * @return void
      */
-    protected function reindexCategoryList(array $categoryIds)
+    private function reindexCategoryList(array $categoryIds): void
     {
         if (!$this->categoryIndexer->isScheduled()) {
             $this->categoryIndexer->reindexList($categoryIds);

--- a/Plugin/Quote/OnCartAddTrackingEventPlugin.php
+++ b/Plugin/Quote/OnCartAddTrackingEventPlugin.php
@@ -35,8 +35,7 @@ class OnCartAddTrackingEventPlugin
         DataStorageInterface $cartItemsToAddDataStorage,
         EventTrackingConfig $eventTrackingConfig,
         DataObjectFactory $dataObjectFactory
-    )
-    {
+    ) {
         $this->cartItemsToAddDataStorage = $cartItemsToAddDataStorage;
         $this->eventTrackingConfig = $eventTrackingConfig;
         $this->dataObjectFactory = $dataObjectFactory;
@@ -47,23 +46,19 @@ class OnCartAddTrackingEventPlugin
      *
      * @param Quote $subject
      * @param int $itemId
-     * @return null
      * @noinspection PhpMissingParamTypeInspection
      */
-    public function beforeUpdateItem(Quote $subject, $itemId)
+    public function beforeUpdateItem(Quote $subject, $itemId): void
     {
         $item = $subject->getItemById($itemId);
         $this->qty = $item ? $item->getQty() : 0;
         $this->isSkipAddNewItem = true;
-
-        return null;
     }
 
     /**
-     * @return QuoteItem
      * @throws RuntimeException
      */
-    public function afterUpdateItem(Quote $subject, QuoteItem $result)
+    public function afterUpdateItem(Quote $subject, QuoteItem $result): QuoteItem
     {
         $this->isSkipAddNewItem = false;
         if ($this->qty > $result->getQty()) {
@@ -81,17 +76,12 @@ class OnCartAddTrackingEventPlugin
      * @param Quote $subject
      * @param Product $product
      * @param float|DataObject|null $request
-     * @return null
      * @noinspection PhpMissingParamTypeInspection
      */
-    public function beforeAddProduct(
-        Quote $subject,
-        Product $product,
-        $request = null
-    )
+    public function beforeAddProduct(Quote $subject, Product $product, $request = null): void
     {
         if ($this->isSkipAddNewItem) {
-            return null;
+            return;
         }
 
         if ($request === null) {
@@ -101,12 +91,10 @@ class OnCartAddTrackingEventPlugin
             $request = $this->dataObjectFactory->create(['qty' => $request]);
         }
         if (!$request instanceof \Magento\Framework\DataObject) {
-            return null;
+            return;
         }
 
         $this->qty = (float)$request->getData('qty') ?: 0;
-
-        return null;
     }
 
     /**
@@ -115,11 +103,9 @@ class OnCartAddTrackingEventPlugin
      * @return QuoteItem|string
      * @throws RuntimeException
      * @noinspection PhpMissingParamTypeInspection
+     * @noinspection PhpMissingReturnTypeInspection
      */
-    public function afterAddProduct(
-        Quote $subject,
-        $result
-    )
+    public function afterAddProduct(Quote $subject, $result)
     {
         if ($this->isSkipAddNewItem) {
             return $result;
@@ -147,10 +133,9 @@ class OnCartAddTrackingEventPlugin
     }
 
     /**
-     * @return void
      * @throws RuntimeException
      */
-    private function addItemToTriggerList(QuoteItem $item)
+    private function addItemToTriggerList(QuoteItem $item): void
     {
         if ($this->eventTrackingConfig->isEnabled()) {
             $this->cartItemsToAddDataStorage->reset();

--- a/Plugin/Quote/OnCartRemoveTrackingEventPlugin.php
+++ b/Plugin/Quote/OnCartRemoveTrackingEventPlugin.php
@@ -28,8 +28,7 @@ class OnCartRemoveTrackingEventPlugin
     public function __construct(
         DataStorageInterface $cartItemsToRemoveDataStorage,
         EventTrackingConfig $eventTrackingConfig
-    )
-    {
+    ) {
         $this->cartItemsToRemoveDataStorage = $cartItemsToRemoveDataStorage;
         $this->eventTrackingConfig = $eventTrackingConfig;
     }
@@ -37,15 +36,12 @@ class OnCartRemoveTrackingEventPlugin
     /**
      * @param Quote $subject
      * @param int $itemId
-     * @return null
      * @noinspection PhpMissingParamTypeInspection
      */
-    public function beforeUpdateItem(Quote $subject, $itemId)
+    public function beforeUpdateItem(Quote $subject, $itemId): void
     {
         $item = $subject->getItemById($itemId);
         $this->qty = $item ? $item->getQty() : 0;
-
-        return null;
     }
 
     /**
@@ -56,7 +52,7 @@ class OnCartRemoveTrackingEventPlugin
      * @throws \Magento\Framework\Exception\RuntimeException
      * @noinspection PhpMissingParamTypeInspection
      */
-    public function afterUpdateItem(Quote $subject, QuoteItem $result, $itemId)
+    public function afterUpdateItem(Quote $subject, QuoteItem $result, $itemId): QuoteItem
     {
         if ($this->qty > $result->getQty() && (int)$itemId === (int)$result->getItemId()) {
             $this->addItemToTriggerList($result, $this->qty - $result->getQty());
@@ -73,7 +69,7 @@ class OnCartRemoveTrackingEventPlugin
      * @throws \Magento\Framework\Exception\RuntimeException
      * @noinspection PhpMissingParamTypeInspection
      */
-    public function afterRemoveItem(Quote $subject, Quote $result, $itemId)
+    public function afterRemoveItem(Quote $subject, Quote $result, $itemId): Quote
     {
         $item = $subject->getItemById($itemId);
         if ($item instanceof QuoteItem) {
@@ -84,10 +80,9 @@ class OnCartRemoveTrackingEventPlugin
     }
 
     /**
-     * @return void
      * @throws \Magento\Framework\Exception\RuntimeException
      */
-    private function addItemToTriggerList(QuoteItem $resultItem, float $qty)
+    private function addItemToTriggerList(QuoteItem $resultItem, float $qty): void
     {
         if ($this->eventTrackingConfig->isEnabled()) {
             $this->cartItemsToRemoveDataStorage->reset();

--- a/Plugin/Store/AbstractPlugin.php
+++ b/Plugin/Store/AbstractPlugin.php
@@ -20,8 +20,6 @@ abstract class AbstractPlugin
 {
     /**
      * Validate changes for invalidating indexer
-     *
-     * @return bool
      */
-    abstract protected function validate(AbstractModel $model);
+    abstract protected function validate(AbstractModel $model): bool;
 }

--- a/Plugin/Store/StoreGroupPlugin.php
+++ b/Plugin/Store/StoreGroupPlugin.php
@@ -33,8 +33,7 @@ class StoreGroupPlugin extends AbstractPlugin
     public function __construct(
         IndexerRegistry $indexerRegistry,
         IndexingConfig $indexingConfig
-    )
-    {
+    ) {
         $this->productIndexer = $indexerRegistry->get(ProductIndexer::INDEXER_ID);
         $this->categoryIndexer = $indexerRegistry->get(CategoryIndexer::INDEXER_ID);
         $this->indexingConfig = $indexingConfig;
@@ -50,8 +49,11 @@ class StoreGroupPlugin extends AbstractPlugin
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function afterSave(StoreGroupResourceModel $subject, StoreGroupResourceModel $result, AbstractModel $group)
-    {
+    public function afterSave(
+        StoreGroupResourceModel $subject,
+        StoreGroupResourceModel $result,
+        AbstractModel $group
+    ): StoreGroupResourceModel {
         if ($this->validate($group)) {
             $this->categoryIndexer->invalidate();
             $this->productIndexer->invalidate();
@@ -66,7 +68,7 @@ class StoreGroupPlugin extends AbstractPlugin
      * @param StoreGroupModel $model
      * @return bool
      */
-    protected function validate(AbstractModel $model)
+    protected function validate(AbstractModel $model): bool
     {
         $isIndexingEnabled = false;
         /** @var Store $store */

--- a/Plugin/Store/StoreViewDisableIndexingPlugin.php
+++ b/Plugin/Store/StoreViewDisableIndexingPlugin.php
@@ -32,8 +32,7 @@ class StoreViewDisableIndexingPlugin
         IndexingConfig $indexingConfig,
         WriterInterface $configWriter,
         ReinitableConfigInterface $reinitableConfig
-    )
-    {
+    ) {
         $this->indexingConfig = $indexingConfig;
         $this->configWriter = $configWriter;
         $this->reinitableConfig = $reinitableConfig;
@@ -49,8 +48,11 @@ class StoreViewDisableIndexingPlugin
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function afterSave(StoreResourceModel $subject, StoreResourceModel $result, AbstractModel $store)
-    {
+    public function afterSave(
+        StoreResourceModel $subject,
+        StoreResourceModel $result,
+        AbstractModel $store
+    ): StoreResourceModel {
         if ($store->isObjectNew() && $this->indexingConfig->isIndexingEnabled($store->getId())) {
             $this->configWriter->save(
                 $this->indexingConfig->getPath(IndexingConfig::CONFIG_ENABLE_INDEXING),

--- a/Plugin/Store/StoreViewPlugin.php
+++ b/Plugin/Store/StoreViewPlugin.php
@@ -32,8 +32,7 @@ class StoreViewPlugin extends AbstractPlugin
     public function __construct(
         IndexerRegistry $indexerRegistry,
         IndexingConfig $indexingConfig
-    )
-    {
+    ) {
         $this->productIndexer = $indexerRegistry->get(ProductIndexer::INDEXER_ID);
         $this->categoryIndexer = $indexerRegistry->get(CategoryIndexer::INDEXER_ID);
         $this->indexingConfig = $indexingConfig;
@@ -46,8 +45,11 @@ class StoreViewPlugin extends AbstractPlugin
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function afterSave(StoreResourceModel $subject, StoreResourceModel $result, AbstractModel $store)
-    {
+    public function afterSave(
+        StoreResourceModel $subject,
+        StoreResourceModel $result,
+        AbstractModel $store
+    ): StoreResourceModel {
         if ($this->validate($store)) {
             $this->categoryIndexer->invalidate();
             $this->productIndexer->invalidate();
@@ -56,7 +58,7 @@ class StoreViewPlugin extends AbstractPlugin
         return $result;
     }
 
-    protected function validate(AbstractModel $model)
+    protected function validate(AbstractModel $model): bool
     {
         /** @var StoreModel $model */
         return !$model->isObjectNew()

--- a/Setup/Patch/Data/FieldMappingConfigPatch.php
+++ b/Setup/Patch/Data/FieldMappingConfigPatch.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Setup\Patch\Data;
 
-use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
@@ -29,26 +28,28 @@ class FieldMappingConfigPatch implements DataPatchInterface
     public function __construct(
         ModuleDataSetupInterface $moduleDataSetup,
         Json $json
-    )
-    {
+    ) {
         $this->moduleDataSetup = $moduleDataSetup;
         $this->json = $json;
     }
 
-    public static function getDependencies()
-    {
-        return [];
-    }
-
-    public function getAliases()
+    /**
+     * @return string[]
+     */
+    public static function getDependencies(): array
     {
         return [];
     }
 
     /**
-     * @throws LocalizedException
+     * @return string[]
      */
-    public function apply()
+    public function getAliases(): array
+    {
+        return [];
+    }
+
+    public function apply(): self
     {
         $configTable = $this->moduleDataSetup->getTable('core_config_data');
         $select = $this->moduleDataSetup->getConnection()->select()
@@ -71,5 +72,7 @@ class FieldMappingConfigPatch implements DataPatchInterface
                 ['path = ?' => self::CONFIG_PATH_ATTRIBUTES]
             );
         }
+
+        return $this;
     }
 }


### PR DESCRIPTION
| Q             | A
|---------------| ---
| Branch?       | 0.8
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| BC breaks?    | no
| Tests pass?   | yes
| Tickets       | HC-1703

This PR turns `@return` annotations on private methods into return type declarations and add return types on all private/internal methods if `@return` anootation wasn't specified. With the help of Symfony's patch-type-declarations script.
