### PR TITLE
fix: return type mismatch

### DIFF
--- a/Api/Data/BoostQueryInterface.php
+++ b/Api/Data/BoostQueryInterface.php
@@ -22,24 +22,11 @@ interface BoostQueryInterface
     public const FIELD_QUERY = 'Query';
     public const FIELD_BOOST = 'Boost';
 
-    /**
-     * @return string
-     */
     public function getQuery(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setQuery(?string $value): self;
 
-    /**
-     * @return float
-     */
     public function getBoost(): float;
-
-    /**
-     * @return $this
-     */
+    
     public function setBoost(float $value): self;
 }

--- a/Api/Data/ClientDataInterface.php
+++ b/Api/Data/ClientDataInterface.php
@@ -43,7 +43,7 @@ interface ClientDataInterface
     public function setVisitId(?string $value): self;
 
     /**
-     * @return array
+     * @return array<string, string>
      */
     public function getCustom(): array;
 
@@ -53,7 +53,7 @@ interface ClientDataInterface
     public function setCustom(?array $value): self;
 
     /**
-     * @return array
+     * @return array<string, list<string>>
      */
     public function getExtendedCustom(): array;
 
@@ -63,7 +63,7 @@ interface ClientDataInterface
     public function setExtendedCustom(?array $value): self;
 
     /**
-     * @return array
+     * @return list<int>
      */
     public function getPreviewBuckets(): array;
 

--- a/Api/Data/ClientDataInterface.php
+++ b/Api/Data/ClientDataInterface.php
@@ -34,26 +34,12 @@ interface ClientDataInterface
     const FIELD_ORIGIN = 'Origin';
     const FIELD_ZIP_CODE = 'ZipCode';
 
-    /**
-     * @return string
-     */
     public function getVisitorId(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setVisitorId(?string $value): self;
 
-    /**
-     * @return string
-     */
     public function getVisitId(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setVisitId(?string $value): self;
 
     /**
@@ -63,7 +49,6 @@ interface ClientDataInterface
 
     /**
      * @param array<string, string>|null $value
-     * @return $this
      */
     public function setCustom(?array $value): self;
 
@@ -74,7 +59,6 @@ interface ClientDataInterface
 
     /**
      * @param array<string, list<string>>|null $value
-     * @return $this
      */
     public function setExtendedCustom(?array $value): self;
 
@@ -85,40 +69,18 @@ interface ClientDataInterface
 
     /**
      * @param list<int>|null $value
-     * @return $this
      */
     public function setPreviewBuckets(?array $value): self;
 
-    /**
-     * @return string
-     */
     public function getSource(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setSource(?string $value): self;
 
-    /**
-     * @return \HawkSearch\EsIndexing\Api\Data\CoordinateInterface
-     */
     public function getOrigin(): CoordinateInterface;
 
-    /**
-     * @param \HawkSearch\EsIndexing\Api\Data\CoordinateInterface|null $value
-     * @return $this
-     */
     public function setOrigin(?CoordinateInterface $value): self;
 
-    /**
-     * @return string
-     */
     public function getZipCode(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setZipCode(?string $value): self;
 }

--- a/Api/Data/CoordinateInterface.php
+++ b/Api/Data/CoordinateInterface.php
@@ -27,23 +27,11 @@ interface CoordinateInterface
     const FIELD_LATITUDE = 'Latitude';
     const FIELD_LONGITUDE = 'Longitude';
 
-    /**
-     * @return float
-     */
     public function getLatitude(): float;
 
-    /**
-     * @return $this
-     */
     public function setLatitude(float $value): self;
 
-    /**
-     * @return float
-     */
     public function getLongitude(): float;
 
-    /**
-     * @return $this
-     */
     public function setLongitude(float $value): self;
 }

--- a/Api/Data/EsIndexInterface.php
+++ b/Api/Data/EsIndexInterface.php
@@ -25,13 +25,7 @@ interface EsIndexInterface
 {
     public const INDEX_NAME = 'IndexName';
 
-    /**
-     * @return string|null
-     */
     public function getIndexName(): ?string;
 
-    /**
-     * @return $this
-     */
     public function setIndexName(string $value);
 }

--- a/Api/Data/EsIndexInterface.php
+++ b/Api/Data/EsIndexInterface.php
@@ -27,5 +27,8 @@ interface EsIndexInterface
 
     public function getIndexName(): ?string;
 
+    /**
+     * @return $this
+     */
     public function setIndexName(string $value);
 }

--- a/Api/Data/FacetBoostBuryInterface.php
+++ b/Api/Data/FacetBoostBuryInterface.php
@@ -31,25 +31,22 @@ interface FacetBoostBuryInterface
     const BURY_VALUES = 'BuryValues';
 
     /**
-     * @return \HawkSearch\EsIndexing\Api\Data\FacetValueOrderInfoInterface[]
+     * @return FacetValueOrderInfoInterface[]
      */
     public function getBoostValues(): array;
 
     /**
-     * @param \HawkSearch\EsIndexing\Api\Data\FacetValueOrderInfoInterface[]|null $value
-     * @return $this
+     * @param FacetValueOrderInfoInterface[]|null $value
      */
     public function setBoostValues(?array $value): self;
 
     /**
-     * @return \HawkSearch\EsIndexing\Api\Data\FacetValueOrderInfoInterface[]
+     * @return FacetValueOrderInfoInterface[]
      */
     public function getBuryValues(): array;
 
     /**
-     * @param \HawkSearch\EsIndexing\Api\Data\FacetValueOrderInfoInterface[]|null $value
-     * @return $this
+     * @param FacetValueOrderInfoInterface[]|null $value
      */
     public function setBuryValues(?array $value): self;
-
 }

--- a/Api/Data/FacetInterface.php
+++ b/Api/Data/FacetInterface.php
@@ -72,475 +72,189 @@ interface FacetInterface
     const CURRENCY_SYMBOL = 'CurrencySymbol';
     const DEFAULT_ITEM_TYPE = 'DefaultItemType';
 
-    /**
-     * @return string
-     */
     public function getSyncGuid(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setSyncGuid(?string $value): self;
 
-    /**
-     * @return int
-     */
     public function getFacetId(): int;
 
-    /**
-     * @return $this
-     */
     public function setFacetId(int $value): self;
 
-    /**
-     * @return string
-     */
     public function getName(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setName(?string $value): self;
 
-    /**
-     * @return string
-     */
     public function getFacetType(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setFacetType(?string $value): self;
 
-    /**
-     * @return string
-     */
     public function getFieldType(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setFieldType(?string $value): self;
 
-    /**
-     * @return int
-     */
     public function getMaxCount(): int;
 
-    /**
-     * @return $this
-     */
     public function setMaxCount(int $value): self;
 
-    /**
-     * @return int
-     */
     public function getMinHitCount(): int;
 
-    /**
-     * @return $this
-     */
     public function setMinHitCount(int $value): self;
 
-    /**
-     * @return string
-     */
     public function getField(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setField(?string $value): self;
 
-    /**
-     * @return string
-     */
     public function getParam(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setParam(?string $value): self;
 
-    /**
-     * @return string
-     */
     public function getDisplayType(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setDisplayType(?string $value): self;
 
-    /**
-     * @return int
-     */
     public function getScrollHeight(): int;
 
-    /**
-     * @return $this
-     */
     public function setScrollHeight(int $value): self;
 
-    /**
-     * @return int
-     */
     public function getScrollThreshold(): int;
 
-    /**
-     * @return $this
-     */
     public function setScrollThreshold(int $value): self;
 
-    /**
-     * @return int
-     */
     public function getTruncateThreshold(): int;
 
-    /**
-     * @return $this
-     */
     public function setTruncateThreshold(int $value): self;
 
-    /**
-     * @return int
-     */
     public function getSearchThreshold(): int;
 
-    /**
-     * @return $this
-     */
     public function setSearchThreshold(int $value): self;
 
-    /**
-     * @return int
-     */
     public function getSortOrder(): int;
 
-    /**
-     * @return $this
-     */
     public function setSortOrder(int $value): self;
 
-    /**
-     * @return bool
-     */
     public function getExpandSelection(): bool;
 
-    /**
-     * @return $this
-     */
     public function setExpandSelection(bool $value): self;
 
-    /**
-     * @return bool
-     */
     public function getIsCurrency(): bool;
 
-    /**
-     * @return $this
-     */
     public function setIsCurrency(bool $value): self;
 
-    /**
-     * @return bool
-     */
     public function getIsNumeric(): bool;
 
-    /**
-     * @return $this
-     */
     public function setIsNumeric(bool $value): self;
 
-    /**
-     * @return bool
-     */
     public function getIsSearch(): bool;
 
-    /**
-     * @return $this
-     */
     public function setIsSearch(bool $value): self;
 
-    /**
-     * @return bool
-     */
     public function getIsVisible(): bool;
 
-    /**
-     * @return $this
-     */
     public function setIsVisible(bool $value): self;
 
-    /**
-     * @return string
-     */
     public function getUBound(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setUBound(?string $value): self;
 
-    /**
-     * @return string
-     */
     public function getLBound(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setLBound(?string $value): self;
 
-    /**
-     * @return string
-     */
     public function getIncrement(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setIncrement(?string $value): self;
 
-    /**
-     * @return int
-     */
     public function getNofVisible(): int;
 
-    /**
-     * @return $this
-     */
     public function setNofVisible(int $value): self;
 
-    /**
-     * @return int
-     */
     public function getHeight(): int;
 
-    /**
-     * @return $this
-     */
     public function setHeight(int $value): self;
 
-    /**
-     * @return string
-     */
     public function getDisplayRuleXML(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setDisplayRuleXML(?string $value): self;
 
-    /**
-     * @return string
-     */
     public function getSortBy(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setSortBy(?string $value): self;
 
-    /**
-     * @return int
-     */
     public function getParentId(): int;
 
-    /**
-     * @return $this
-     */
     public function setParentId(int $value): self;
 
-    /**
-     * @return bool
-     */
     public function getIsCollapsible(): bool;
 
-    /**
-     * @return $this
-     */
     public function setIsCollapsible(bool $value): self;
 
-    /**
-     * @return bool
-     */
     public function getIsCollapsedDefault(): bool;
 
-    /**
-     * @return $this
-     */
     public function setIsCollapsedDefault(bool $value): self;
 
-    /**
-     * @return string
-     */
     public function getSwatchData(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setSwatchData(?string $value): self;
 
-    /**
-     * @return int
-     */
     public function getFacetRangeDisplayType(): int;
 
-    /**
-     * @return $this
-     */
     public function setFacetRangeDisplayType(int $value): self;
 
-    /**
-     * @return bool
-     */
     public function getPreloadChildren(): bool;
 
-    /**
-     * @return $this
-     */
     public function setPreloadChildren(bool $value): self;
 
-    /**
-     * @return string
-     */
     public function getTooltip(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setTooltip(?string $value): self;
 
-    /**
-     * @return bool
-     */
     public function getShowSliderInputs(): bool;
 
-    /**
-     * @return $this
-     */
     public function setShowSliderInputs(bool $value): self;
 
-    /**
-     * @return bool
-     */
     public function getShowFacetImageCount(): bool;
 
-    /**
-     * @return $this
-     */
     public function setShowFacetImageCount(bool $value): self;
 
     /**
-     * @return \HawkSearch\EsIndexing\Api\Data\FacetRangeModelInterface[]
+     * @return FacetRangeModelInterface[]
      */
     public function getFacetRanges(): array;
 
     /**
-     * @param \HawkSearch\EsIndexing\Api\Data\FacetRangeModelInterface[]|null $value
-     * @return $this
+     * @param FacetRangeModelInterface[]|null $value
      */
     public function setFacetRanges(?array $value): self;
 
-    /**
-     * @return string
-     */
     public function getTags(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setTags(?string $value): self;
 
-    /**
-     * @return string
-     */
     public function getCreateDate(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setCreateDate(?string $value): self;
 
-    /**
-     * @return string
-     */
     public function getModifyDate(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setModifyDate(?string $value): self;
 
-    /**
-     * @return \HawkSearch\EsIndexing\Api\Data\FacetBoostBuryInterface
-     */
     public function getBoostBury(): FacetBoostBuryInterface;
-
-    /**
-     * @param \HawkSearch\EsIndexing\Api\Data\FacetBoostBuryInterface|null $value
-     * @return $this
-     */
+    
     public function setBoostBury(?FacetBoostBuryInterface $value): self;
 
-    /**
-     * @return string
-     */
     public function getListName(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setListName(?string $value): self;
 
-    /**
-     * @return int
-     */
     public function getNumericPrecision(): int;
 
-    /**
-     * @return $this
-     */
     public function setNumericPrecision(int $value): self;
 
-    /**
-     * @return string
-     */
     public function getCurrencySymbol(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setCurrencySymbol(?string $value): self;
 
-    /**
-     * @return string
-     */
     public function getDefaultItemType(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setDefaultItemType(?string $value): self;
 }

--- a/Api/Data/FacetRangeModelInterface.php
+++ b/Api/Data/FacetRangeModelInterface.php
@@ -35,78 +35,31 @@ interface FacetRangeModelInterface
     const ASSET_NAME = 'AssetName';
     const ASSET_URL = 'AssetUrl';
 
-    /**
-     * @return int
-     */
     public function getRangeId(): int;
 
-    /**
-     * @return $this
-     */
     public function setRangeId(int $value): self;
 
-    /**
-     * @return string
-     */
     public function getName(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setName(?string $value): self;
 
-    /**
-     * @return string
-     */
     public function getLBound(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setLBound(?string $value): self;
 
-    /**
-     * @return string
-     */
     public function getUBound(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setUBound(?string $value): self;
 
-    /**
-     * @return int
-     */
     public function getSortOrder(): int;
 
-    /**
-     * @return $this
-     */
     public function setSortOrder(int $value): self;
 
-    /**
-     * @return string
-     */
     public function getAssetName(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setAssetName(?string $value): self;
 
-    /**
-     * @return string
-     */
     public function getAssetUrl(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setAssetUrl(?string $value): self;
 }

--- a/Api/Data/FacetValueOrderInfoInterface.php
+++ b/Api/Data/FacetValueOrderInfoInterface.php
@@ -30,24 +30,11 @@ interface FacetValueOrderInfoInterface
     const VALUE = 'Value';
     const SORT_ORDER = 'SortOrder';
 
-    /**
-     * @return string
-     */
     public function getValue(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setValue(?string $value): self;
 
-    /**
-     * @return int
-     */
     public function getSortOrder(): int;
 
-    /**
-     * @return $this
-     */
     public function setSortOrder(int $value): self;
 }

--- a/Api/Data/FieldInterface.php
+++ b/Api/Data/FieldInterface.php
@@ -74,365 +74,144 @@ interface FieldInterface
     const FIELD_TYPE_UNINDEXED = 'unindexed';
     const FIELD_TYPE_TEXT = 'text';
 
-    /**
-     * @return int
-     */
     public function getFieldId(): int;
 
-    /**
-     * @return $this
-     */
     public function setFieldId(int $value): self;
 
-    /**
-     * @return string
-     */
     public function getSyncGuid(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setSyncGuid(?string $value): self;
 
-    /**
-     * @return string
-     */
     public function getLabel(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setLabel(?string $value): self;
 
-    /**
-     * @return string
-     */
     public function getName(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setName(?string $value): self;
 
-    /**
-     * @return bool
-     */
     public function getIsPrimaryKey(): bool;
 
-    /**
-     * @return $this
-     */
     public function setIsPrimaryKey(bool $value): self;
 
-    /**
-     * @return string
-     */
     public function getType(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setType(?string $value): self;
 
-    /**
-     * @return string
-     */
     public function getFieldType(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setFieldType(?string $value): self;
 
-    /**
-     * @return int
-     */
     public function getBoost(): int;
 
-    /**
-     * @return $this
-     */
     public function setBoost(int $value): self;
 
-    /**
-     * @return int
-     */
     public function getFacetHandler(): int;
 
-    /**
-     * @return $this
-     */
     public function setFacetHandler(int $value): self;
 
-    /**
-     * @return bool
-     */
     public function getIsOutput(): bool;
 
-    /**
-     * @return $this
-     */
     public function setIsOutput(bool $value): self;
 
-    /**
-     * @return bool
-     */
     public function getIsShingle(): bool;
 
-    /**
-     * @return $this
-     */
     public function setIsShingle(bool $value): self;
 
-    /**
-     * @return bool
-     */
     public function getIsBestFragment(): bool;
 
-    /**
-     * @return $this
-     */
     public function setIsBestFragment(bool $value): self;
 
-    /**
-     * @return bool
-     */
     public function getIsDictionary(): bool;
 
-    /**
-     * @return $this
-     */
     public function setIsDictionary(bool $value): self;
 
-    /**
-     * @return bool
-     */
     public function getIsSort(): bool;
 
-    /**
-     * @return $this
-     */
     public function setIsSort(bool $value): self;
 
-    /**
-     * @return bool
-     */
     public function getIsPrefix(): bool;
 
-    /**
-     * @return $this
-     */
     public function setIsPrefix(bool $value): self;
 
-    /**
-     * @return bool
-     */
     public function getIsHidden(): bool;
 
-    /**
-     * @return $this
-     */
     public function setIsHidden(bool $value): self;
 
-    /**
-     * @return bool
-     */
     public function getIsCompare(): bool;
 
-    /**
-     * @return $this
-     */
     public function setIsCompare(bool $value): self;
 
-    /**
-     * @return int
-     */
     public function getSortOrder(): int;
 
-    /**
-     * @return $this
-     */
     public function setSortOrder(int $value): self;
 
-    /**
-     * @return string
-     */
     public function getPartialQuery(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setPartialQuery(?string $value): self;
 
-    /**
-     * @return bool
-     */
     public function getIsKeywordText(): bool;
 
-    /**
-     * @return $this
-     */
     public function setIsKeywordText(bool $value): self;
 
-    /**
-     * @return bool
-     */
     public function getIsQuery(): bool;
 
-    /**
-     * @return $this
-     */
     public function setIsQuery(bool $value): self;
 
-    /**
-     * @return bool
-     */
     public function getIsQueryText(): bool;
 
-    /**
-     * @return $this
-     */
     public function setIsQueryText(bool $value): self;
 
-    /**
-     * @return bool
-     */
     public function getSkipCustom(): bool;
 
-    /**
-     * @return $this
-     */
     public function setSkipCustom(bool $value): self;
 
-    /**
-     * @return bool
-     */
     public function getStripHtml(): bool;
 
-    /**
-     * @return $this
-     */
     public function setStripHtml(bool $value): self;
 
-    /**
-     * @return int
-     */
     public function getMinNGramAnalyzer(): int;
 
-    /**
-     * @return $this
-     */
     public function setMinNGramAnalyzer(int $value): self;
 
-    /**
-     * @return int
-     */
     public function getMaxNGramAnalyzer(): int;
 
-    /**
-     * @return $this
-     */
     public function setMaxNGramAnalyzer(int $value): self;
 
-    /**
-     * @return int
-     */
     public function getCoordinateType(): int;
 
-    /**
-     * @return $this
-     */
     public function setCoordinateType(int $value): self;
 
-    /**
-     * @return bool
-     */
     public function getOmitNorms(): bool;
 
-    /**
-     * @return $this
-     */
     public function setOmitNorms(bool $value): self;
 
-    /**
-     * @return string
-     */
     public function getItemMapping(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setItemMapping(?string $value): self;
 
-    /**
-     * @return string
-     */
     public function getDefaultValue(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setDefaultValue(?string $value): self;
 
-    /**
-     * @return bool
-     */
     public function getUseForPrediction(): bool;
 
-    /**
-     * @return $this
-     */
     public function setUseForPrediction(bool $value): self;
 
-    /**
-     * @return string
-     */
     public function getCopyTo(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setCopyTo(?string $value): self;
 
-    /**
-     * @return string
-     */
     public function getAnalyzer(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setAnalyzer(?string $value): self;
 
-    /**
-     * @return bool
-     */
     public function getDoNotStore(): bool;
 
-    /**
-     * @return $this
-     */
     public function setDoNotStore(bool $value): self;
 
-    /**
-     * @return string
-     */
     public function getTags(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setTags(?string $value): self;
 
     /**
@@ -442,81 +221,34 @@ interface FieldInterface
 
     /**
      * @param int[]|null $value
-     * @return $this
      */
     public function setIterations(?array $value): self;
 
-    /**
-     * @return string
-     */
     public function getAnalyzerLanguage(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setAnalyzerLanguage(?string $value): self;
 
-    /**
-     * @return string
-     */
     public function getPreviewMapping(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setPreviewMapping(?string $value): self;
 
-    /**
-     * @return bool
-     */
     public function getOmitTfAndPos(): bool;
 
-    /**
-     * @return $this
-     */
     public function setOmitTfAndPos(bool $value): self;
 
-    /**
-     * @return string
-     */
     public function getCreateDate(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setCreateDate(?string $value): self;
 
-    /**
-     * @return string
-     */
     public function getModifyDate(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setModifyDate(?string $value): self;
 
-    /**
-     * @return bool
-     */
     public function getIsChild(): bool;
 
-    /**
-     * @return $this
-     */
     public function setIsChild(bool $value): self;
 
-    /**
-     * @return bool
-     */
     public function getIsHierarchical(): bool;
 
-    /**
-     * @return $this
-     */
     public function setIsHierarchical(bool $value): self;
 }

--- a/Api/Data/HierarchyInterface.php
+++ b/Api/Data/HierarchyInterface.php
@@ -33,9 +33,6 @@ interface HierarchyInterface
     public const FIELD_SORTORDER = "SortOrder";
     public const FIELD_CUSTOM = "Custom";
 
-    /**
-     * @return string
-     */
     public function getHierarchyId(): string;
 
     /**
@@ -43,9 +40,6 @@ interface HierarchyInterface
      */
     public function setHierarchyId(string $value);
 
-    /**
-     * @return string
-     */
     public function getName(): string;
 
     /**
@@ -53,9 +47,6 @@ interface HierarchyInterface
      */
     public function setName(string $value);
 
-    /**
-     * @return string
-     */
     public function getParentHierarchyId(): string;
 
     /**
@@ -63,9 +54,6 @@ interface HierarchyInterface
      */
     public function setParentHierarchyId(string $value);
 
-    /**
-     * @return bool
-     */
     public function getIsActive(): bool;
 
     /**
@@ -73,9 +61,6 @@ interface HierarchyInterface
      */
     public function setIsActive(bool $value);
 
-    /**
-     * @return int
-     */
     public function getSortOrder(): int;
 
     /**
@@ -83,9 +68,6 @@ interface HierarchyInterface
      */
     public function setSortOrder(int $value);
 
-    /**
-     * @return string
-     */
     public function getCustom(): string;
 
     /**

--- a/Api/Data/IndexItemsContextInterface.php
+++ b/Api/Data/IndexItemsContextInterface.php
@@ -27,15 +27,8 @@ interface IndexItemsContextInterface
     public const FIELD_INDEX_NAME = 'IndexName';
     public const FIELD_ITEMS = 'Items';
 
-    /**
-     * @return string
-     */
     public function getIndexName(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setIndexName(?string $value): self;
 
     /**
@@ -45,7 +38,6 @@ interface IndexItemsContextInterface
 
     /**
      * @param IndexItemInterface[]|null $value
-     * @return $this
      */
     public function setItems(?array $value): self;
 }

--- a/Api/Data/LandingPageInterface.php
+++ b/Api/Data/LandingPageInterface.php
@@ -54,64 +54,41 @@ interface LandingPageInterface
     public const FIELD_IS_NO_FOLLOW = "IsNoFollow";
     public const FIELD_CUSTOM_SORT_LIST = "CustomSortList";
 
-    /**
-     * @return int|null
-     */
     public function getPageId(): ?int;
 
     /**
-     * @param int|null $value
      * @return $this
      */
     public function setPageId(?int $value);
 
-    /**
-     * @return string|null
-     */
     public function getSyncGuid(): ?string;
 
     /**
-     * @param string|null $value
      * @return $this
      */
     public function setSyncGuid(?string $value);
 
-    /**
-     * @return string|null
-     */
     public function getName(): ?string;
 
     /**
-     * @param string|null $value
      * @return $this
      */
     public function setName(?string $value);
 
-    /**
-     * @return string|null
-     */
     public function getCustomUrl(): ?string;
 
     /**
-     * @param string|null $value
      * @return $this
      */
     public function setCustomUrl(?string $value);
 
-    /**
-     * @return string|null
-     */
     public function getNarrowXml(): ?string;
 
     /**
-     * @param string|null $value
      * @return $this
      */
     public function setNarrowXml(?string $value);
 
-    /**
-     * @return bool
-     */
     public function getIsFacetOverride(): bool;
 
     /**
@@ -119,9 +96,6 @@ interface LandingPageInterface
      */
     public function setIsFacetOverride(bool $value);
 
-    /**
-     * @return bool
-     */
     public function getIsIncludeProducts(): bool;
 
     /**
@@ -129,24 +103,16 @@ interface LandingPageInterface
      */
     public function setIsIncludeProducts(bool $value);
 
-    /**
-     * @return string|null
-     */
     public function getSortFieldId(): ?string;
 
     /**
-     * @param string|null $value
      * @return $this
      */
     public function setSortFieldId(?string $value);
 
-    /**
-     * @return string|null
-     */
     public function getSortDirection(): ?string;
 
     /**
-     * @param string|null $value
      * @return $this
      */
     public function setSortDirection(?string $value);
@@ -162,20 +128,13 @@ interface LandingPageInterface
      */
     public function setSelectedFacets(array $value);
 
-    /**
-     * @return string|null
-     */
     public function getPageLayoutId(): ?string;
 
     /**
-     * @param string|null $value
      * @return $this
      */
     public function setPageLayoutId(?string $value);
 
-    /**
-     * @return bool
-     */
     public function getEnableFacetAutoOrdering(): bool;
 
     /**
@@ -183,46 +142,30 @@ interface LandingPageInterface
      */
     public function setEnableFacetAutoOrdering(bool $value);
 
-    /**
-     * @return string|null
-     */
     public function getCustom(): ?string;
 
     /**
-     * @param string|null $value
      * @return $this
      */
     public function setCustom(?string $value);
 
-    /**
-     * @return string|null
-     */
     public function getTags(): ?string;
 
     /**
-     * @param string|null $value
      * @return $this
      */
     public function setTags(?string $value);
 
-    /**
-     * @return string|null
-     */
     public function getCanonicalUrl(): ?string;
 
     /**
-     * @param string|null $value
      * @return $this
      */
     public function setCanonicalUrl(?string $value);
 
-    /**
-     * @return string|null
-     */
     public function getPageType(): ?string;
 
     /**
-     * @param string|null $value
      * @return $this
      */
     public function setPageType(?string $value);
@@ -238,86 +181,55 @@ interface LandingPageInterface
      */
     public function setContentConfigList(array $value);
 
-    /**
-     * @return string|null
-     */
     public function getPageHeading(): ?string;
 
     /**
-     * @param string|null $value
      * @return $this
      */
     public function setPageHeading(?string $value);
 
-    /**
-     * @return string|null
-     */
     public function getCustomHtml(): ?string;
 
     /**
-     * @param string|null $value
      * @return $this
      */
     public function setCustomHtml(?string $value);
 
-    /**
-     * @return string|null
-     */
     public function getKeywords(): ?string;
 
     /**
-     * @param string|null $value
      * @return $this
      */
     public function setKeywords(?string $value);
 
-    /**
-     * @return string|null
-     */
     public function getListName(): ?string;
 
     /**
-     * @param string|null $value
      * @return $this
      */
     public function setListName(?string $value);
 
-    /**
-     * @return string|null
-     */
     public function getNotes(): ?string;
 
     /**
-     * @param string|null $value
      * @return $this
      */
     public function setNotes(?string $value);
 
-    /**
-     * @return string|null
-     */
     public function getCreateDate(): ?string;
 
     /**
-     * @param string|null $value
      * @return $this
      */
     public function setCreateDate(?string $value);
 
-    /**
-     * @return string|null
-     */
     public function getModifyDate(): ?string;
 
     /**
-     * @param string|null $value
      * @return $this
      */
     public function setModifyDate(?string $value);
 
-    /**
-     * @return bool
-     */
     public function getIsNoIndex(): bool;
 
     /**
@@ -325,9 +237,6 @@ interface LandingPageInterface
      */
     public function setIsNoIndex(bool $value);
 
-    /**
-     * @return bool
-     */
     public function getIsNoFollow(): bool;
 
     /**
@@ -335,13 +244,9 @@ interface LandingPageInterface
      */
     public function setIsNoFollow(bool $value);
 
-    /**
-     * @return string|null
-     */
     public function getCustomSortList(): ?string;
 
     /**
-     * @param string|null $value
      * @return $this
      */
     public function setCustomSortList(?string $value);

--- a/Api/Data/SearchRequestInterface.php
+++ b/Api/Data/SearchRequestInterface.php
@@ -55,198 +55,84 @@ interface SearchRequestInterface
     public const FIELD_SEARCH_TYPE = 'SearchType';
     public const FIELD_IGNORE_SPELLCHECK = 'IgnoreSpellcheck';
 
-    /**
-     * @return string
-     */
     public function getIndexName(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setIndexName(?string $value): self;
 
-    /**
-     * @return string
-     */
     public function getQuery(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setQuery(?string $value): self;
 
 
-    /**
-     * @return \HawkSearch\EsIndexing\Api\Data\VariantOptionsInterface
-     */
     public function getVariant(): VariantOptionsInterface;
 
 
-    /**
-     * @param \HawkSearch\EsIndexing\Api\Data\VariantOptionsInterface|null $value
-     * @return $this
-     */
     public function setVariant(?VariantOptionsInterface $value): self;
 
     /**
-     * @return \HawkSearch\EsIndexing\Api\Data\BoostQueryInterface[]
+     * @return BoostQueryInterface[]
      */
     public function getBoostQueries(): array;
 
     /**
-     * @param \HawkSearch\EsIndexing\Api\Data\BoostQueryInterface[]|null $value
-     * @return $this
+     * @param BoostQueryInterface[]|null $value
      */
     public function setBoostQueries(?array $value): self;
 
-    /**
-     * @return int
-     */
     public function getDistanceUnitType(): int;
 
-    /**
-     * @return $this
-     */
     public function setDistanceUnitType(int $value): self;
 
-    /**
-     * @return int
-     */
     public function getRequestType(): int;
 
-    /**
-     * @return $this
-     */
     public function setRequestType(int $value): self;
 
-    /**
-     * @return string
-     */
     public function getImageData(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setImageData(?string $value): self;
 
-    /**
-     * @return string
-     */
     public function getImageText(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setImageText(?string $value): self;
 
-    /**
-     * @return int
-     */
     public function getKValue(): int;
 
-    /**
-     * @return $this
-     */
     public function setKValue(int $value): self;
 
-    /**
-     * @return string
-     */
     public function getClientGuid(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setClientGuid(?string $value): self;
 
-    /**
-     * @return string
-     */
     public function getKeyword(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setKeyword(?string $value): self;
 
-    /**
-     * @return int
-     */
     public function getPageId(): int;
 
-    /**
-     * @return $this
-     */
     public function setPageId(int $value): self;
 
-    /**
-     * @return int
-     */
     public function getPageNo(): int;
 
-    /**
-     * @return $this
-     */
     public function setPageNo(int $value): self;
 
-    /**
-     * @return int
-     */
     public function getMaxPerPage(): int;
 
-    /**
-     * @return $this
-     */
     public function setMaxPerPage(int $value): self;
 
-    /**
-     * @return string
-     */
     public function getSearchWithin(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setSearchWithin(?string $value): self;
 
-    /**
-     * @return string
-     */
     public function getSortBy(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setSortBy(?string $value): self;
 
-    /**
-     * @return string
-     */
     public function getSortingSetCode(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setSortingSetCode(?string $value): self;
 
-    /**
-     * @return string
-     */
     public function getPaginationSetCode(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setPaginationSetCode(?string $value): self;
 
     /**
@@ -256,50 +142,23 @@ interface SearchRequestInterface
 
     /**
      * @param array<string, list<array<string, mixed>>>|null $value
-     * @return $this
      */
     public function setFacetSelections(?array $value): self;
 
-    /**
-     * @return string
-     */
     public function getCustomUrl(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setCustomUrl(?string $value): self;
 
-    /**
-     * @return bool
-     */
     public function getIsInPreview(): bool;
 
-    /**
-     * @return $this
-     */
     public function setIsInPreview(bool $value): self;
 
-    /**
-     * @return bool
-     */
     public function getIs100CoverageTurnedOn(): bool;
 
-    /**
-     * @return $this
-     */
     public function setIs100CoverageTurnedOn(bool $value): self;
 
-    /**
-     * @return string
-     */
     public function getExplainDocId(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setExplainDocId(?string $value): self;
 
     /**
@@ -309,7 +168,6 @@ interface SearchRequestInterface
 
     /**
      * @param string[]|null $value
-     * @return $this
      */
     public function setFacetOverride(?array $value): self;
 
@@ -320,50 +178,22 @@ interface SearchRequestInterface
 
     /**
      * @param string[]|null $value
-     * @return $this
      */
     public function setFieldOverride(?array $value): self;
 
-    /**
-     * @return \HawkSearch\EsIndexing\Api\Data\SmartBarInterface
-     */
     public function getSmartBar(): SmartBarInterface;
 
-    /**
-     * @param \HawkSearch\EsIndexing\Api\Data\SmartBarInterface|null $value
-     * @return $this
-     */
     public function setSmartBar(?SmartBarInterface $value): self;
 
-    /**
-     * @return \HawkSearch\EsIndexing\Api\Data\ClientDataInterface
-     */
     public function getClientData(): ClientDataInterface;
 
-    /**
-     * @param \HawkSearch\EsIndexing\Api\Data\ClientDataInterface|null $value
-     * @return $this
-     */
     public function setClientData(?ClientDataInterface $value): self;
 
-    /**
-     * @return string
-     */
     public function getSearchType(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setSearchType(?string $value): self;
 
-    /**
-     * @return bool
-     */
     public function getIgnoreSpellcheck(): bool;
 
-    /**
-     * @return $this
-     */
     public function setIgnoreSpellcheck(bool $value): self;
 }

--- a/Api/Data/SearchRequestInterface.php
+++ b/Api/Data/SearchRequestInterface.php
@@ -136,12 +136,12 @@ interface SearchRequestInterface
     public function setPaginationSetCode(?string $value): self;
 
     /**
-     * @return array
+     * @return array<string, list<array<string, string>>>
      */
     public function getFacetSelections(): array;
 
     /**
-     * @param array<string, list<array<string, mixed>>>|null $value
+     * @param array<string, list<array<string, string>>>|null $value
      */
     public function setFacetSelections(?array $value): self;
 

--- a/Api/Data/SmartBarInterface.php
+++ b/Api/Data/SmartBarInterface.php
@@ -30,105 +30,44 @@ interface SmartBarInterface
     public const FIELD_KEYWORD_REPLACEMENT = 'KeywordReplacement';
     public const FIELD_PREVIEW_DATE = 'PreviewDate';
 
-    /**
-     * @return bool
-     */
     public function getBoostAndBury(): bool;
 
-    /**
-     * @return $this
-     */
     public function setBoostAndBury(bool $value): self;
 
-    /**
-     * @return bool
-     */
     public function getVisibilityRules(): bool;
 
-    /**
-     * @return $this
-     */
     public function setVisibilityRules(bool $value): self;
 
-    /**
-     * @return bool
-     */
     public function getPersonalizedBoost(): bool;
 
-    /**
-     * @return $this
-     */
     public function setPersonalizedBoost(bool $value): self;
 
-    /**
-     * @return bool
-     */
     public function getPopularityBoost(): bool;
 
-    /**
-     * @return $this
-     */
     public function setPopularityBoost(bool $value): self;
 
-    /**
-     * @return bool
-     */
     public function getItemPin(): bool;
 
-    /**
-     * @return $this
-     */
     public function setItemPin(bool $value): self;
 
-    /**
-     * @return bool
-     */
     public function getPopularitySalesBoost(): bool;
 
-    /**
-     * @return $this
-     */
     public function setPopularitySalesBoost(bool $value): self;
 
-    /**
-     * @return bool
-     */
     public function getPopularityAdd2CartBoost(): bool;
 
-    /**
-     * @return $this
-     */
     public function setPopularityAdd2CartBoost(bool $value): self;
 
-    /**
-     * @return bool
-     */
     public function getPopularityLandingPageBoost(): bool;
 
-    /**
-     * @return $this
-     */
     public function setPopularityLandingPageBoost(bool $value): self;
 
-    /**
-     * @return bool
-     */
     public function getKeywordReplacement(): bool;
 
-    /**
-     * @return $this
-     */
     public function setKeywordReplacement(bool $value): self;
 
-    /**
-     * @return string
-     */
     public function getPreviewDate(): string;
-
-    /**
-     * @param string|null $value
-     * @return $this
-     */
+    
     public function setPreviewDate(?string $value): self;
 
 }

--- a/Api/Data/VariantOptionsInterface.php
+++ b/Api/Data/VariantOptionsInterface.php
@@ -25,55 +25,23 @@ interface VariantOptionsInterface
     public const FIELD_SORT_CODE = 'SortCode';
     public const FIELD_SORT_BY = 'SortBy';
 
-    /**
-     * @return bool
-     */
     public function getCountFacetHitOnChild(): bool;
 
-    /**
-     * @return $this
-     */
     public function setCountFacetHitOnChild(bool $value): self;
 
-    /**
-     * @return int
-     */
     public function getPageNo(): int;
 
-    /**
-     * @return $this
-     */
     public function setPageNo(int $value): self;
 
-    /**
-     * @return int
-     */
     public function getMaxPerPage(): int;
 
-    /**
-     * @return $this
-     */
     public function setMaxPerPage(int $value): self;
 
-    /**
-     * @return string
-     */
     public function getSortCode(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setSortCode(?string $value): self;
 
-    /**
-     * @return string
-     */
     public function getSortBy(): string;
 
-    /**
-     * @param string|null $value
-     * @return $this
-     */
     public function setSortBy(?string $value): self;
 }

--- a/Api/FacetManagementInterface.php
+++ b/Api/FacetManagementInterface.php
@@ -31,13 +31,11 @@ interface FacetManagementInterface
     public function getFacets(): array;
 
     /**
-     * @return FacetInterface
      * @throws CouldNotSaveException
      */
     public function addFacet(FacetInterface $facet): FacetInterface;
 
     /**
-     * @return FacetInterface
      * @throws CouldNotSaveException
      */
     public function updateFacet(FacetInterface $facet): FacetInterface;

--- a/Api/FieldManagementInterface.php
+++ b/Api/FieldManagementInterface.php
@@ -38,13 +38,11 @@ interface FieldManagementInterface
     public function getFields(): array;
 
     /**
-     * @return FieldInterface
      * @throws CouldNotSaveException
      */
     public function addField(FieldInterface $field): FieldInterface;
 
     /**
-     * @return FieldInterface
      * @throws CouldNotSaveException
      */
     public function updateField(FieldInterface $field): FieldInterface;

--- a/Api/LandingPageManagementInterface.php
+++ b/Api/LandingPageManagementInterface.php
@@ -10,6 +10,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+
 namespace HawkSearch\EsIndexing\Api;
 
 use HawkSearch\EsIndexing\Api\Data\LandingPageInterface;
@@ -28,7 +29,7 @@ interface LandingPageManagementInterface
     public function getLandingPages();
 
     /**
-     * @return array
+     * @return list<string>
      */
     public function getLandingPageUrls();
 

--- a/Block/Adminhtml/Bulk/Details/BackButton.php
+++ b/Block/Adminhtml/Bulk/Details/BackButton.php
@@ -10,6 +10,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+
 namespace HawkSearch\EsIndexing\Block\Adminhtml\Bulk\Details;
 
 use HawkSearch\EsIndexing\Block\Adminhtml\Form\GenericButton;
@@ -22,7 +23,7 @@ use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
 class BackButton extends GenericButton implements ButtonProviderInterface
 {
     /**
-     * @return array
+     * @return array<string, string|\Stringable|int>
      */
     public function getButtonData()
     {

--- a/Block/Adminhtml/Bulk/Details/RetryButton.php
+++ b/Block/Adminhtml/Bulk/Details/RetryButton.php
@@ -36,7 +36,7 @@ class RetryButton implements ButtonProviderInterface
     }
 
     /**
-     * @return array
+     * @return array<string, string|\Stringable|array<mixed>>
      */
     public function getButtonData()
     {

--- a/Block/Adminhtml/Form/Field/Select.php
+++ b/Block/Adminhtml/Form/Field/Select.php
@@ -25,6 +25,7 @@ class Select extends HtmlSelect
      */
     public function setInputName(string $value)
     {
+        /** @var $this */
         return $this->setName($value);
     }
 

--- a/Block/Adminhtml/System/Config/Product/CustomAttributes.php
+++ b/Block/Adminhtml/System/Config/Product/CustomAttributes.php
@@ -83,7 +83,7 @@ class CustomAttributes extends AbstractFieldArray
     {
         $this->setHtmlId('_' . uniqid());
         $this->_addAfter = false;
-        $this->_addButtonLabel = __('Add New Mapping');
+        $this->_addButtonLabel = __('Add New Mapping')->render();
 
         $this->addColumn(
             ValueProcessorInterface::COLUMN_FIELD,
@@ -121,6 +121,7 @@ class CustomAttributes extends AbstractFieldArray
     {
         parent::addColumn($name, $params);
 
+        /** @phpstan-ignore nullCoalesce.expr (PhpDoc for $this->_getParam lies) */
         $options = $this->_getParam($params, 'options') ?? [];
 
         if (is_callable($options)) {

--- a/Block/Adminhtml/System/Config/Product/CustomAttributes.php
+++ b/Block/Adminhtml/System/Config/Product/CustomAttributes.php
@@ -202,7 +202,6 @@ class CustomAttributes extends AbstractFieldArray
 
     /**
      * @param list<array<mixed>> $options
-     * @return Select
      * @throws LocalizedException
      */
     private function getRenderer(array $options): Select

--- a/Block/Html/Head/JsConfig.php
+++ b/Block/Html/Head/JsConfig.php
@@ -48,6 +48,6 @@ class JsConfig extends Template
      */
     public function getJsLayout()
     {
-        return $this->serializer->serialize($this->configProcessor->process($this->jsLayout ?? []));
+        return $this->serializer->serialize($this->configProcessor->process($this->jsLayout));
     }
 }

--- a/Block/Tracking.php
+++ b/Block/Tracking.php
@@ -92,7 +92,7 @@ class Tracking extends Template
     /**
      * Gete orders and items data as array
      *
-     * @return array
+     * @return array<string, mixed>
      * @throws NoSuchEntityException
      */
     public function getOrderData()

--- a/Block/Tracking.php
+++ b/Block/Tracking.php
@@ -90,9 +90,9 @@ class Tracking extends Template
     }
 
     /**
-     * Gete orders and items data as array
+     * Get orders and items data as array
      *
-     * @return array<string, mixed>
+     * @return list<array<string, mixed>>
      * @throws NoSuchEntityException
      */
     public function getOrderData()

--- a/Console/Command/RetryBulk.php
+++ b/Console/Command/RetryBulk.php
@@ -78,9 +78,6 @@ class RetryBulk extends Command
         parent::configure();
     }
 
-    /**
-     * @return int
-     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $bulkUuid = $input->getArgument(self::INPUT_BULK_UUID);

--- a/Controller/LandingPage/View.php
+++ b/Controller/LandingPage/View.php
@@ -50,9 +50,6 @@ class View extends \Magento\Framework\App\Action\Action
         $this->landingPageInterfaceFactory = $landingPageInterfaceFactory;
     }
 
-    /**
-     * @return ResultInterface
-     */
     public function execute(): ResultInterface
     {
         $category = $this->categoryFactory->create();

--- a/Gateway/Instruction/Result/EsIndexResult.php
+++ b/Gateway/Instruction/Result/EsIndexResult.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace HawkSearch\EsIndexing\Gateway\Instruction\Result;
 
 use HawkSearch\Connector\Gateway\Helper\HttpResponseReader;
+use HawkSearch\Connector\Gateway\Http\ClientInterface;
 use HawkSearch\Connector\Gateway\Instruction\ResultInterface;
 use HawkSearch\Connector\Helper\DataObjectHelper as HawkSearchDataObjectHelper;
 use HawkSearch\EsIndexing\Api\Data\EsIndexInterface;
@@ -22,7 +23,7 @@ use HawkSearch\EsIndexing\Api\Data\EsIndexInterfaceFactory;
 use Magento\Framework\Api\DataObjectHelper;
 
 /**
- * @phpstan-import-type HttpResult from ResultInterface
+ * @phpstan-import-type HttpResult from ClientInterface
  */
 class EsIndexResult implements ResultInterface
 {
@@ -49,8 +50,7 @@ class EsIndexResult implements ResultInterface
         HawkSearchDataObjectHelper $hawksearchDataObjectHelper,
         HttpResponseReader $httpResponseReader,
         array $result = []
-    )
-    {
+    ) {
         $this->esIndexFactory = $esIndexFactory;
         $this->dataObjectHelper = $dataObjectHelper;
         $this->hawksearchDataObjectHelper = $hawksearchDataObjectHelper;

--- a/Gateway/Instruction/Result/FacetListResult.php
+++ b/Gateway/Instruction/Result/FacetListResult.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace HawkSearch\EsIndexing\Gateway\Instruction\Result;
 
 use HawkSearch\Connector\Gateway\Helper\HttpResponseReader;
+use HawkSearch\Connector\Gateway\Http\ClientInterface;
 use HawkSearch\Connector\Gateway\Instruction\ResultInterface;
 use HawkSearch\Connector\Helper\DataObjectHelper as HawkSearchDataObjectHelper;
 use HawkSearch\EsIndexing\Api\Data\FacetInterface;
@@ -22,7 +23,7 @@ use HawkSearch\EsIndexing\Api\Data\FacetInterfaceFactory;
 use Magento\Framework\Api\DataObjectHelper;
 
 /**
- * @phpstan-import-type HttpResult from ResultInterface
+ * @phpstan-import-type HttpResult from ClientInterface
  */
 class FacetListResult implements ResultInterface
 {
@@ -49,8 +50,7 @@ class FacetListResult implements ResultInterface
         HawkSearchDataObjectHelper $hawksearchDataObjectHelper,
         HttpResponseReader $httpResponseReader,
         array $result = []
-    )
-    {
+    ) {
         $this->facetFactory = $facetFactory;
         $this->dataObjectHelper = $dataObjectHelper;
         $this->hawksearchDataObjectHelper = $hawksearchDataObjectHelper;

--- a/Gateway/Instruction/Result/FacetResult.php
+++ b/Gateway/Instruction/Result/FacetResult.php
@@ -59,8 +59,6 @@ class FacetResult implements ResultInterface
 
     /**
      * Returns facet result interpretation
-     *
-     * @return FacetInterface
      */
     public function get(): FacetInterface
     {

--- a/Gateway/Instruction/Result/FacetResult.php
+++ b/Gateway/Instruction/Result/FacetResult.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace HawkSearch\EsIndexing\Gateway\Instruction\Result;
 
 use HawkSearch\Connector\Gateway\Helper\HttpResponseReader;
+use HawkSearch\Connector\Gateway\Http\ClientInterface;
 use HawkSearch\Connector\Gateway\Instruction\ResultInterface;
 use HawkSearch\Connector\Helper\DataObjectHelper as HawkSearchDataObjectHelper;
 use HawkSearch\EsIndexing\Api\Data\FacetInterface;
@@ -22,7 +23,7 @@ use HawkSearch\EsIndexing\Api\Data\FacetInterfaceFactory;
 use Magento\Framework\Api\DataObjectHelper;
 
 /**
- * @phpstan-import-type HttpResult from ResultInterface
+ * @phpstan-import-type HttpResult from ClientInterface
  */
 class FacetResult implements ResultInterface
 {
@@ -48,8 +49,7 @@ class FacetResult implements ResultInterface
         HawkSearchDataObjectHelper $hawksearchDataObjectHelper,
         HttpResponseReader $httpResponseReader,
         array $result = []
-    )
-    {
+    ) {
         $this->result = $result;
         $this->facetFactory = $facetFactory;
         $this->dataObjectHelper = $dataObjectHelper;

--- a/Gateway/Instruction/Result/FieldListResult.php
+++ b/Gateway/Instruction/Result/FieldListResult.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace HawkSearch\EsIndexing\Gateway\Instruction\Result;
 
 use HawkSearch\Connector\Gateway\Helper\HttpResponseReader;
+use HawkSearch\Connector\Gateway\Http\ClientInterface;
 use HawkSearch\Connector\Gateway\Instruction\ResultInterface;
 use HawkSearch\Connector\Helper\DataObjectHelper as HawkSearchDataObjectHelper;
 use HawkSearch\EsIndexing\Api\Data\FieldInterface;
@@ -22,7 +23,7 @@ use HawkSearch\EsIndexing\Api\Data\FieldInterfaceFactory;
 use Magento\Framework\Api\DataObjectHelper;
 
 /**
- * @phpstan-import-type HttpResult from ResultInterface
+ * @phpstan-import-type HttpResult from ClientInterface
  */
 class FieldListResult implements ResultInterface
 {
@@ -48,8 +49,7 @@ class FieldListResult implements ResultInterface
         HawkSearchDataObjectHelper $hawksearchDataObjectHelper,
         HttpResponseReader $httpResponseReader,
         array $result = []
-    )
-    {
+    ) {
         $this->result = $result;
         $this->fieldFactory = $fieldInterfaceFactory;
         $this->dataObjectHelper = $dataObjectHelper;

--- a/Gateway/Instruction/Result/FieldResult.php
+++ b/Gateway/Instruction/Result/FieldResult.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace HawkSearch\EsIndexing\Gateway\Instruction\Result;
 
 use HawkSearch\Connector\Gateway\Helper\HttpResponseReader;
+use HawkSearch\Connector\Gateway\Http\ClientInterface;
 use HawkSearch\Connector\Gateway\Instruction\ResultInterface;
 use HawkSearch\Connector\Helper\DataObjectHelper as HawkSearchDataObjectHelper;
 use HawkSearch\EsIndexing\Api\Data\FieldInterface;
@@ -22,7 +23,7 @@ use HawkSearch\EsIndexing\Api\Data\FieldInterfaceFactory;
 use Magento\Framework\Api\DataObjectHelper;
 
 /**
- * @phpstan-import-type HttpResult from ResultInterface
+ * @phpstan-import-type HttpResult from ClientInterface
  */
 class FieldResult implements ResultInterface
 {
@@ -48,8 +49,7 @@ class FieldResult implements ResultInterface
         HawkSearchDataObjectHelper $hawksearchDataObjectHelper,
         HttpResponseReader $httpResponseReader,
         array $result = []
-    )
-    {
+    ) {
         $this->result = $result;
         $this->fieldFactory = $fieldFactory;
         $this->dataObjectHelper = $dataObjectHelper;

--- a/Gateway/Instruction/Result/FieldResult.php
+++ b/Gateway/Instruction/Result/FieldResult.php
@@ -59,8 +59,6 @@ class FieldResult implements ResultInterface
 
     /**
      * Returns result interpretation
-     *
-     * @return FieldInterface
      */
     public function get(): FieldInterface
     {

--- a/Gateway/Instruction/Result/IndexListResult.php
+++ b/Gateway/Instruction/Result/IndexListResult.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace HawkSearch\EsIndexing\Gateway\Instruction\Result;
 
 use HawkSearch\Connector\Gateway\Helper\HttpResponseReader;
+use HawkSearch\Connector\Gateway\Http\ClientInterface;
 use HawkSearch\Connector\Gateway\Instruction\ResultInterface;
 use HawkSearch\Connector\Helper\DataObjectHelper as HawkSearchDataObjectHelper;
 use HawkSearch\EsIndexing\Api\Data\IndexListInterface;
@@ -22,7 +23,7 @@ use HawkSearch\EsIndexing\Api\Data\IndexListInterfaceFactory;
 use Magento\Framework\Api\DataObjectHelper;
 
 /**
- * @phpstan-import-type HttpResult from ResultInterface
+ * @phpstan-import-type HttpResult from ClientInterface
  */
 class IndexListResult implements ResultInterface
 {
@@ -49,8 +50,7 @@ class IndexListResult implements ResultInterface
         HawkSearchDataObjectHelper $hawksearchDataObjectHelper,
         HttpResponseReader $httpResponseReader,
         array $result = []
-    )
-    {
+    ) {
         $this->indexListFactory = $indexListFactory;
         $this->dataObjectHelper = $dataObjectHelper;
         $this->hawksearchDataObjectHelper = $hawksearchDataObjectHelper;

--- a/Gateway/Instruction/Result/LandingPageResult.php
+++ b/Gateway/Instruction/Result/LandingPageResult.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace HawkSearch\EsIndexing\Gateway\Instruction\Result;
 
 use HawkSearch\Connector\Gateway\Helper\HttpResponseReader;
+use HawkSearch\Connector\Gateway\Http\ClientInterface;
 use HawkSearch\Connector\Gateway\Instruction\ResultInterface;
 use HawkSearch\Connector\Helper\DataObjectHelper as HawkSearchDataObjectHelper;
 use HawkSearch\EsIndexing\Api\Data\LandingPageInterface;
@@ -22,7 +23,7 @@ use HawkSearch\EsIndexing\Api\Data\LandingPageInterfaceFactory;
 use Magento\Framework\Api\DataObjectHelper;
 
 /**
- * @phpstan-import-type HttpResult from ResultInterface
+ * @phpstan-import-type HttpResult from ClientInterface
  */
 class LandingPageResult implements ResultInterface
 {
@@ -49,8 +50,7 @@ class LandingPageResult implements ResultInterface
         HawkSearchDataObjectHelper $hawksearchDataObjectHelper,
         HttpResponseReader $httpResponseReader,
         array $result = []
-    )
-    {
+    ) {
         $this->landingPageFactory = $landingPageFactory;
         $this->dataObjectHelper = $dataObjectHelper;
         $this->hawksearchDataObjectHelper = $hawksearchDataObjectHelper;

--- a/Helper/ObjectHelper.php
+++ b/Helper/ObjectHelper.php
@@ -25,6 +25,13 @@ use Magento\Framework\Api\SortOrderFactory;
 /**
  * @api
  * @since 0.8.0
+ *
+ * @phpstan-type SearchCriteriaData array{
+ *     filter_groups?: array<mixed>,
+ *     sort_orders?: array<mixed>,
+ *     page_size?: ?int,
+ *     current_page?: ?int,
+ * }
  */
 class ObjectHelper
 {
@@ -46,16 +53,7 @@ class ObjectHelper
     }
 
     /**
-     * @phpstan-type keyFilterGroups SearchCriteria::FILTER_GROUPS
-     * @phpstan-type keySortOrders SearchCriteria::SORT_ORDERS
-     * @phpstan-type keyPageSize SearchCriteria::PAGE_SIZE
-     * @phpstan-type keyCurrentPage SearchCriteria::CURRENT_PAGE
-     * @param array{
-     *              keyFilterGroups: array<mixed>,
-     *              keySortOrders: array<mixed>,
-     *              keyPageSize: ?int,
-     *              keyCurrentPage: ?int,
-     *        } $data
+     * @param SearchCriteriaData $data
      * @return SearchCriteria
      */
     public function convertArrayToSearchCriteriaObject(array $data)

--- a/Model/Api/SearchCriteria/CollectionProcessor/CustomJoinProcessor.php
+++ b/Model/Api/SearchCriteria/CollectionProcessor/CustomJoinProcessor.php
@@ -57,9 +57,6 @@ class CustomJoinProcessor implements CollectionProcessorInterface
         }
     }
 
-    /**
-     * @return void
-     */
     private function applyCustomJoin(string $joinName, AbstractDb $collection): void
     {
         $customJoin = $this->getCustomJoin($joinName);
@@ -71,7 +68,6 @@ class CustomJoinProcessor implements CollectionProcessorInterface
     }
 
     /**
-     * @return CustomJoinInterface|null
      * @throws \InvalidArgumentException
      */
     private function getCustomJoin(string $joinName): ?CustomJoinInterface

--- a/Model/Config/Advanced.php
+++ b/Model/Config/Advanced.php
@@ -25,7 +25,6 @@ class Advanced extends ConfigProvider
      * Check if setting is enabled
      *
      * @param null|int|string $store
-     * @return bool
      * @noinspection PhpMissingParamTypeInspection
      */
     public function isRemovePubFromAssetsUrl($store = null): bool

--- a/Model/Config/AdvancedCategory.php
+++ b/Model/Config/AdvancedCategory.php
@@ -25,7 +25,6 @@ class AdvancedCategory extends ConfigProvider
      * Returns a threshold for the amount of excepted Product URL rewrites
      *
      * @param null|int|string $store
-     * @return int
      * @noinspection PhpMissingParamTypeInspection
      */
     public function getProductUrlRewriteExceptionsThreshold($store = null): int

--- a/Model/Config/Backend/Serialized/Processor/ProductAttributes.php
+++ b/Model/Config/Backend/Serialized/Processor/ProductAttributes.php
@@ -34,14 +34,7 @@ use Magento\Framework\Serialize\SerializerInterface;
 use Psr\Log\LoggerInterface;
 
 /**
- * @phpstan-type keyColumnField ValueProcessorInterface::COLUMN_FIELD
- * @phpstan-type keyColumnAttribute ValueProcessorInterface::COLUMN_ATTRIBUTE
- * @phpstan-type keyColumnFieldNew ValueProcessorInterface::COLUMN_FIELD_NEW
- * @phpstan-type ValueItemRow array{
- *     keyColumnField: string,
- *     keyColumnAttribute: string,
- *     keyColumnFieldNew?: string
- * }
+ * @phpstan-type ValueItemRow array<self::COLUMN_*, string>
  * @phpstan-type ValueItems array<string, ValueItemRow>
  * @implements ValueProcessorInterface<ValueItems, ValueItems>
  */

--- a/Model/Config/Backend/Serialized/Processor/ProductAttributes.php
+++ b/Model/Config/Backend/Serialized/Processor/ProductAttributes.php
@@ -34,7 +34,14 @@ use Magento\Framework\Serialize\SerializerInterface;
 use Psr\Log\LoggerInterface;
 
 /**
- * @phpstan-type ValueItemRow array{'field': string, 'attribute': string, 'field_new'?: string}
+ * @phpstan-type keyColumnField ValueProcessorInterface::COLUMN_FIELD
+ * @phpstan-type keyColumnAttribute ValueProcessorInterface::COLUMN_ATTRIBUTE
+ * @phpstan-type keyColumnFieldNew ValueProcessorInterface::COLUMN_FIELD_NEW
+ * @phpstan-type ValueItemRow array{
+ *     keyColumnField: string,
+ *     keyColumnAttribute: string,
+ *     keyColumnFieldNew?: string
+ * }
  * @phpstan-type ValueItems array<string, ValueItemRow>
  * @implements ValueProcessorInterface<ValueItems, ValueItems>
  */
@@ -71,8 +78,7 @@ class ProductAttributes implements ValueProcessorInterface
         FacetManagementInterface $facetManagement,
         FieldExtendedInterfaceFactory $fieldExtendedFactory,
         ?SerializerInterface $serializer = null
-    )
-    {
+    ) {
         $this->attributeProvider = $attributeProvider;
         $this->attributeFacade = $attributeFacade;
         $this->message = $message;
@@ -85,6 +91,11 @@ class ProductAttributes implements ValueProcessorInterface
         $this->serializer = $serializer ?? ObjectManager::getInstance()->get(SerializerInterface::class);
     }
 
+    /**
+     * @param ValueItems $value
+     * @param ValueInterface $configValue
+     * @return ValueItems
+     */
     public function process(array $value, ValueInterface $configValue): array
     {
         $value = $resultSave = $this->filterValue($value);

--- a/Model/Config/Backend/Serialized/Processor/ProductAttributes.php
+++ b/Model/Config/Backend/Serialized/Processor/ProductAttributes.php
@@ -201,7 +201,6 @@ class ProductAttributes implements ValueProcessorInterface
 
     /**
      * @param ValueItemRow $fieldData
-     * @return FieldInterface
      * @throws CouldNotSaveException
      */
     protected function addNewFiled(array $fieldData): FieldInterface
@@ -219,7 +218,6 @@ class ProductAttributes implements ValueProcessorInterface
 
     /**
      * @param ValueItemRow $fieldData
-     * @return FieldInterface
      * @throws NotFoundException|CouldNotSaveException
      */
     protected function updateFiled(array $fieldData): FieldInterface
@@ -247,9 +245,6 @@ class ProductAttributes implements ValueProcessorInterface
         return $this->fieldsCache;
     }
 
-    /**
-     * @return FieldInterface
-     */
     protected function getFieldByName(string $name): FieldInterface
     {
         foreach ($this->getFields() as $field) {
@@ -273,9 +268,6 @@ class ProductAttributes implements ValueProcessorInterface
         return $this->facetsCache;
     }
 
-    /**
-     * @return FacetInterface
-     */
     protected function getFacetByField(FieldExtendedInterface $field): FacetInterface
     {
         $result = $this->facetFactory->create();
@@ -299,7 +291,6 @@ class ProductAttributes implements ValueProcessorInterface
     }
 
     /**
-     * @return FacetInterface
      * @throws CouldNotSaveException
      */
     protected function updateFacet(FieldExtendedInterface $field): FacetInterface

--- a/Model/Config/EventTracking.php
+++ b/Model/Config/EventTracking.php
@@ -28,7 +28,6 @@ class EventTracking extends ConfigProvider
      * Check if Event Tracking is enabled for selected store
      *
      * @param null|int|string $store
-     * @return bool
      * @noinspection PhpMissingParamTypeInspection
      */
     public function isEnabled($store = null): bool

--- a/Model/Config/Indexing.php
+++ b/Model/Config/Indexing.php
@@ -29,7 +29,6 @@ class Indexing extends ConfigProvider
      * Return items batch size for indexing job single operation
      *
      * @param null|int|string $store
-     * @return int
      * @noinspection PhpMissingParamTypeInspection
      */
     public function getItemsBatchSize($store = null): int
@@ -41,7 +40,6 @@ class Indexing extends ConfigProvider
      * Check if backend indexing is enabled for selected store
      *
      * @param null|int|string $store
-     * @return bool
      * @noinspection PhpMissingParamTypeInspection
      */
     public function isIndexingEnabled($store = null): bool
@@ -53,7 +51,6 @@ class Indexing extends ConfigProvider
      * Check if products should include hierarchy with all parent categories
      *
      * @param null|int|string $store
-     * @return bool
      * @noinspection PhpMissingParamTypeInspection
      */
     public function isProductsIncludeCategoriesHierarchy($store = null): bool

--- a/Model/Config/Indexing/FailureRecovery.php
+++ b/Model/Config/Indexing/FailureRecovery.php
@@ -32,7 +32,6 @@ class FailureRecovery extends ConfigProvider
      * Check if Failure Recovery automation cron is enabled
      *
      * @param null|int|string $store
-     * @return bool
      * @noinspection PhpMissingParamTypeInspection
      */
     public function isEnabled($store = null): bool
@@ -44,7 +43,6 @@ class FailureRecovery extends ConfigProvider
      * Return the maximum number of times to retry processing an event after an error occurred
      *
      * @param null|int|string $store
-     * @return int
      * @noinspection PhpMissingParamTypeInspection
      */
     public function getMaximumRetries($store = null): int
@@ -56,7 +54,6 @@ class FailureRecovery extends ConfigProvider
      * Return maximum holding time for incomplete events
      *
      * @param null|int|string $store
-     * @return int
      * @noinspection PhpMissingParamTypeInspection
      */
     public function getMaximumOpenDelay($store = null): int

--- a/Model/Config/Products.php
+++ b/Model/Config/Products.php
@@ -25,7 +25,6 @@ class Products extends ConfigProvider
      * Return product attributes configuration in JSON format
      *
      * @param null|int|string $store
-     * @return string
      * @noinspection PhpMissingParamTypeInspection
      */
     public function getAttributes($store = null): string

--- a/Model/Config/Search.php
+++ b/Model/Config/Search.php
@@ -25,7 +25,6 @@ class Search extends ConfigProvider
      * Check if search is enabled for selected store
      *
      * @param null|int|string $store
-     * @return bool
      * @noinspection PhpMissingParamTypeInspection
      */
     public function isSearchEnabled($store = null): bool

--- a/Model/Cron/RetryFailedOperations.php
+++ b/Model/Cron/RetryFailedOperations.php
@@ -152,6 +152,8 @@ class RetryFailedOperations
         foreach ($items as $item) {
             $item->setData('operation_key', $item->getData('operation_key_orig'));
         }
+
+        /** @var OperationInterface[] */
         return $collection->getItems();
     }
 
@@ -205,6 +207,8 @@ class RetryFailedOperations
         foreach ($items as $item) {
             $item->setData('operation_key', $item->getData('operation_key_orig'));
         }
+
+        /** @var OperationInterface[] */
         return $collection->getItems();
     }
 

--- a/Model/EsIndex.php
+++ b/Model/EsIndex.php
@@ -20,9 +20,6 @@ use Magento\Framework\Api\AbstractSimpleObject;
 
 class EsIndex extends AbstractSimpleObject implements EsIndexInterface
 {
-    /**
-     * @return string
-     */
     public function getIndexName(): string
     {
         return (string)$this->_get(self::INDEX_NAME);

--- a/Model/FacetManagement.php
+++ b/Model/FacetManagement.php
@@ -39,8 +39,7 @@ class FacetManagement implements FacetManagementInterface
      */
     public function __construct(
         InstructionManagerPoolInterface $instructionManagerPool
-    )
-    {
+    ) {
         $this->instructionManagerPool = $instructionManagerPool;
     }
 
@@ -80,6 +79,9 @@ class FacetManagement implements FacetManagementInterface
         return $returnedFacet;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     private function collectFacetData(FacetInterface $facet): array
     {
         if ($facet instanceof AbstractSimpleObject) {

--- a/Model/Field/FieldExtendedInterface.php
+++ b/Model/Field/FieldExtendedInterface.php
@@ -22,25 +22,14 @@ use HawkSearch\EsIndexing\Api\Data\FieldInterface;
  */
 interface FieldExtendedInterface
 {
-    /**
-     * @return bool
-     */
     public function isSearchable(): bool;
 
-    /**
-     * @return bool
-     */
     public function isFilterable(): bool;
 
-    /**
-     * @return bool
-     */
     public function isSortable(): bool;
 
     /**
      * Return initial field
-     *
-     * @return FieldInterface
      */
     public function getField(): FieldInterface;
 }

--- a/Model/Field/Product/AttributeFacade.php
+++ b/Model/Field/Product/AttributeFacade.php
@@ -50,7 +50,7 @@ class AttributeFacade
         return $this;
     }
 
-    private function isFieldSearchable(FieldInterface $field): bool
+    private function isFieldSearchable(FieldInterface $field): bool // @phpstan-ignore method.unused
     {
         return $field->getIsQuery()
             && in_array($field->getFieldType(), ['keyword', 'facet', 'text']);
@@ -72,7 +72,7 @@ class AttributeFacade
 
     }
 
-    private function isFieldFilterable(FieldInterface $field): bool
+    private function isFieldFilterable(FieldInterface $field): bool // @phpstan-ignore method.unused
     {
         return $field->getFieldType() === FieldInterface::FIELD_TYPE_FACET;
     }
@@ -90,7 +90,7 @@ class AttributeFacade
         }
     }
 
-    private function isFieldSortable(FieldInterface $field): bool
+    private function isFieldSortable(FieldInterface $field): bool // @phpstan-ignore method.unused
     {
         return $field->getIsSort();
     }

--- a/Model/FieldManagement.php
+++ b/Model/FieldManagement.php
@@ -40,8 +40,7 @@ class FieldManagement implements FieldManagementInterface
      */
     public function __construct(
         InstructionManagerPoolInterface $instructionManagerPool
-    )
-    {
+    ) {
         $this->instructionManagerPool = $instructionManagerPool;
     }
 
@@ -90,6 +89,9 @@ class FieldManagement implements FieldManagementInterface
         return $returnedField;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     private function collectFieldData(FieldInterface $field): array
     {
         if ($field instanceof AbstractSimpleObject) {

--- a/Model/IndexManagement.php
+++ b/Model/IndexManagement.php
@@ -214,7 +214,7 @@ class IndexManagement implements IndexManagementInterface
     private function getCurrentIndex(): ?string
     {
         $indexFromCache = current($this->getIndicesFromCache(true));
-        if ($indexFromCache === false || $indexFromCache === null) {
+        if ($indexFromCache === false) {
             /** @var EsIndexInterface $result */
             $result = $this->instructionManagerPool->get('hawksearch-esindexing')
                 ->executeByCode('getCurrentIndex')->get();

--- a/Model/IndexManagement.php
+++ b/Model/IndexManagement.php
@@ -85,9 +85,6 @@ class IndexManagement implements IndexManagementInterface
         $this->hawkLogger->info("--- initializeFullReindex FINISHED ---");
     }
 
-    /**
-     * @return string|null
-     */
     public function getIndexName(bool $useCurrent = false): ?string
     {
         $indices = $this->getIndices();

--- a/Model/Indexer/Entities/ActionEntityDefault.php
+++ b/Model/Indexer/Entities/ActionEntityDefault.php
@@ -65,7 +65,9 @@ class ActionEntityDefault extends ActionAbstract
         } catch (\Exception $e) {
             throw new LocalizedException(__($e->getMessage()), $e);
         } finally {
-            $this->storeManager->setCurrentStore($currentStore);
+            if (isset($currentStore)) {
+                $this->storeManager->setCurrentStore($currentStore);
+            }
         }
 
         return $this;

--- a/Model/Indexer/Entities/ActionFull.php
+++ b/Model/Indexer/Entities/ActionFull.php
@@ -65,7 +65,9 @@ class ActionFull extends ActionAbstract
         } catch (\Exception $e) {
             throw new LocalizedException(__($e->getMessage()), $e);
         } finally {
-            $this->storeManager->setCurrentStore($currentStore);
+            if (isset($currentStore)) {
+                $this->storeManager->setCurrentStore($currentStore);
+            }
         }
 
         return $this;

--- a/Model/Indexing/AbstractEntityRebuild.php
+++ b/Model/Indexing/AbstractEntityRebuild.php
@@ -135,7 +135,6 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
      * Check whether item is allowed to be indexed. Otherwise it should be removed.
      *
      * @param TItem $item
-     * @return bool
      */
     abstract protected function isAllowedItem(DataObject $item): bool;
 
@@ -144,7 +143,6 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
      * By default, it is considered that new and existing items are updated through the same indexing endpoint.
      *
      * @param TItem $item
-     * @return bool
      */
     protected function isItemNew(DataObject $item): bool
     {
@@ -154,6 +152,7 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
     /**
      * @param TItem $entityItem
      * @return int
+     * @todo change type: ?int -> int
      */
     abstract protected function getEntityId(DataObject $entityItem): ?int;
 
@@ -441,7 +440,6 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
 
     /**
      * @param TItem|null $item
-     * @return array
      * @deprecated 0.7.0 method will be removed.
      *      Using of 'code' and 'value' options is deprecated. Use @see FieldHandlerInterface to migrate fields with
      *     values.
@@ -545,7 +543,6 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
 
     /**
      * @param TItem $entityItem
-     * @return string
      * @throws NotFoundException
      */
     protected function getEntityUniqueId(DataObject $entityItem): string

--- a/Model/Indexing/AbstractEntityRebuild.php
+++ b/Model/Indexing/AbstractEntityRebuild.php
@@ -435,6 +435,7 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
             $value = array_values($value);
         }
 
+        /** @phpstan-ignore function.impossibleType */
         return $value !== null && !is_array($value) ? [$value] : $value;
     }
 
@@ -515,6 +516,7 @@ abstract class AbstractEntityRebuild implements EntityRebuildInterface
                 $proxyPosition = strlen(get_class($rebuilder)) - strlen('\Proxy');
                 if (strpos(get_class($rebuilder), '\Proxy', -$proxyPosition) === $proxyPosition) {
                     $parentClass = get_parent_class($rebuilder);
+                    /** @phpstan-ignore booleanOr.alwaysTrue */
                     if ($this instanceof $parentClass || is_subclass_of($this, $parentClass)) {
                         break;
                     }

--- a/Model/Indexing/Entity/ContentPage/ItemsDataProvider.php
+++ b/Model/Indexing/Entity/ContentPage/ItemsDataProvider.php
@@ -65,7 +65,7 @@ class ItemsDataProvider implements ItemsDataProviderInterface
             'in'
         );
 
-        if ($entityIds && count($entityIds) > 0) {
+        if ($entityIds) {
             $this->searchCriteriaBuilder->addFilter('page_id', $entityIds, 'in');
         }
 

--- a/Model/Indexing/Entity/ContentPage/ItemsDataProvider.php
+++ b/Model/Indexing/Entity/ContentPage/ItemsDataProvider.php
@@ -21,6 +21,9 @@ use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Store\Model\Store;
 
+/**
+ * @implements ItemsDataProviderInterface<PageInterface>
+ */
 class ItemsDataProvider implements ItemsDataProviderInterface
 {
     private PageRepositoryInterface $pageRepository;
@@ -35,7 +38,6 @@ class ItemsDataProvider implements ItemsDataProviderInterface
     }
 
     /**
-     * @return PageInterface[]
      * @throws LocalizedException
      */
     public function getItems(int $storeId, ?array $entityIds = null, int $currentPage = 1, int $pageSize = 0)
@@ -51,8 +53,12 @@ class ItemsDataProvider implements ItemsDataProviderInterface
      * @return PageInterface[]
      * @throws LocalizedException
      */
-    protected function getPageCollection(int $storeId, ?array $entityIds = null, int $currentPage = 1, int $pageSize = 0)
-    {
+    protected function getPageCollection(
+        int $storeId,
+        ?array $entityIds = null,
+        int $currentPage = 1,
+        int $pageSize = 0
+    ) {
         $this->searchCriteriaBuilder->addFilter(
             'store_id',
             [$storeId, Store::DEFAULT_STORE_ID],

--- a/Model/Indexing/Entity/Hierarchy/ItemsDataProvider.php
+++ b/Model/Indexing/Entity/Hierarchy/ItemsDataProvider.php
@@ -81,7 +81,7 @@ class ItemsDataProvider implements ItemsDataProviderInterface
         $categories->addPathFilter($pathFilterRegex)
             ->addAttributeToSelect('name');
 
-        if ($entityIds && count($entityIds) > 0) {
+        if ($entityIds) {
             $categories->addIdFilter($entityIds);
         }
         $categories->setCurPage($currentPage)

--- a/Model/Indexing/Entity/Hierarchy/ItemsDataProvider.php
+++ b/Model/Indexing/Entity/Hierarchy/ItemsDataProvider.php
@@ -22,6 +22,9 @@ use Magento\Catalog\Model\CategoryFactory;
 use Magento\Catalog\Model\ResourceModel\Category as CategoryResource;
 use Magento\Store\Model\StoreManagerInterface;
 
+/**
+ * @implements ItemsDataProviderInterface<CategoryInterface>
+ */
 class ItemsDataProvider implements ItemsDataProviderInterface
 {
     private CategoryResource $categoryResource;
@@ -32,16 +35,12 @@ class ItemsDataProvider implements ItemsDataProviderInterface
         CategoryResource $categoryResource,
         StoreManagerInterface $storeManager,
         CategoryFactory $categoryFactory
-    )
-    {
+    ) {
         $this->categoryResource = $categoryResource;
         $this->storeManager = $storeManager;
         $this->categoryFactory = $categoryFactory;
     }
 
-    /**
-     * @return CategoryInterface[]
-     */
     public function getItems(int $storeId, ?array $entityIds = null, int $currentPage = 1, int $pageSize = 0)
     {
         return $this->getCategoryCollection($storeId, $entityIds, $currentPage, $pageSize);
@@ -54,8 +53,12 @@ class ItemsDataProvider implements ItemsDataProviderInterface
      * @param int $pageSize
      * @return CategoryInterface[]
      */
-    protected function getCategoryCollection(int $storeId, ?array $entityIds = null, int $currentPage = 1, int $pageSize = 0): array
-    {
+    protected function getCategoryCollection(
+        int $storeId,
+        ?array $entityIds = null,
+        int $currentPage = 1,
+        int $pageSize = 0
+    ): array {
         $storeParentCategoryId = $this->storeManager->getStore($storeId)->getRootCategoryId();
 
         /**

--- a/Model/Indexing/Entity/LandingPage/ItemsDataProvider.php
+++ b/Model/Indexing/Entity/LandingPage/ItemsDataProvider.php
@@ -23,6 +23,9 @@ use Magento\Catalog\Model\ResourceModel\Category as CategoryResource;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Model\StoreManagerInterface;
 
+/**
+ * @implements ItemsDataProviderInterface<CategoryInterface>
+ */
 class ItemsDataProvider implements ItemsDataProviderInterface
 {
     private CategoryResource $categoryResource;
@@ -33,16 +36,12 @@ class ItemsDataProvider implements ItemsDataProviderInterface
         CategoryResource $categoryResource,
         StoreManagerInterface $storeManager,
         CategoryFactory $categoryFactory
-    )
-    {
+    ) {
         $this->categoryResource = $categoryResource;
         $this->storeManager = $storeManager;
         $this->categoryFactory = $categoryFactory;
     }
 
-    /**
-     * @return CategoryInterface[]
-     */
     public function getItems(int $storeId, ?array $entityIds = null, int $currentPage = 1, int $pageSize = 0)
     {
         return $this->getCategoryCollection($storeId, $entityIds, $currentPage, $pageSize);
@@ -56,8 +55,12 @@ class ItemsDataProvider implements ItemsDataProviderInterface
      * @return CategoryInterface[]
      * @throws NoSuchEntityException
      */
-    protected function getCategoryCollection(int $storeId, ?array $entityIds = null, int $currentPage = 1, int $pageSize = 0): array
-    {
+    protected function getCategoryCollection(
+        int $storeId,
+        ?array $entityIds = null,
+        int $currentPage = 1,
+        int $pageSize = 0
+    ): array {
         $storeParentCategoryId = $this->storeManager->getStore($storeId)->getRootCategoryId();
 
         /**

--- a/Model/Indexing/Entity/LandingPage/ItemsDataProvider.php
+++ b/Model/Indexing/Entity/LandingPage/ItemsDataProvider.php
@@ -86,12 +86,13 @@ class ItemsDataProvider implements ItemsDataProviderInterface
             ->addAttributeToSort('parent_id')
             ->addAttributeToSort('position');
 
-        if ($entityIds && count($entityIds) > 0) {
+        if ($entityIds) {
             $categories->addIdFilter($entityIds);
         }
         $categories->setCurPage($currentPage)
             ->setPageSize($pageSize);
 
+        /** @var CategoryInterface[] */
         return $categories->getItems();
     }
 }

--- a/Model/Indexing/Entity/Product/EntityRebuild.php
+++ b/Model/Indexing/Entity/Product/EntityRebuild.php
@@ -41,7 +41,6 @@ class EntityRebuild extends AbstractEntityRebuild
     private Visibility $visibility;
     private Configuration $catalogInventoryConfiguration;
     private StockRegistryInterface $stockRegistry;
-    private Product $productDataProvider;
 
     /**
      * @param EntityTypePoolInterface<string, EntityTypeInterface> $entityTypePool
@@ -54,6 +53,8 @@ class EntityRebuild extends AbstractEntityRebuild
      * @param Configuration $catalogInventoryConfiguration
      * @param StockRegistryInterface $stockRegistry
      * @param Product $productDataProvider
+     * @todo remove $productAttributes argument
+     * @todo remove $productDataProvider argument
      */
     public function __construct(
         EntityTypePoolInterface $entityTypePool,
@@ -80,7 +81,6 @@ class EntityRebuild extends AbstractEntityRebuild
         $this->visibility = $visibility;
         $this->catalogInventoryConfiguration = $catalogInventoryConfiguration;
         $this->stockRegistry = $stockRegistry;
-        $this->productDataProvider = $productDataProvider;
     }
 
     /**

--- a/Model/Indexing/Entity/Product/ItemsDataProvider.php
+++ b/Model/Indexing/Entity/Product/ItemsDataProvider.php
@@ -102,7 +102,7 @@ class ItemsDataProvider implements ItemsDataProviderInterface
     ): array {
         $this->searchCriteriaBuilder->addFilter('store_id', $storeId);
 
-        if ($productIds && count($productIds) > 0) {
+        if ($productIds) {
             $this->searchCriteriaBuilder->addFilter('entity_id', $productIds, 'in');
         }
 

--- a/Model/Indexing/Entity/Product/ItemsDataProvider.php
+++ b/Model/Indexing/Entity/Product/ItemsDataProvider.php
@@ -30,6 +30,7 @@ use Magento\Framework\App\ObjectManager;
 
 /**
  * @phpstan-type ItemType ProductModel
+ * @implements ItemsDataProviderInterface<ItemType>
  */
 class ItemsDataProvider implements ItemsDataProviderInterface
 {
@@ -69,7 +70,6 @@ class ItemsDataProvider implements ItemsDataProviderInterface
     }
 
     /**
-     * @return ItemType[]
      * @throws Exception
      */
     public function getItems(int $storeId, ?array $entityIds = null, int $currentPage = 1, int $pageSize = 0)

--- a/Model/Indexing/EntityType/EntityTypeAbstract.php
+++ b/Model/Indexing/EntityType/EntityTypeAbstract.php
@@ -39,6 +39,9 @@ abstract class EntityTypeAbstract implements EntityTypeInterface
         ],
     ];
     private EntityRebuildInterface $rebuilder;
+    /**
+     * @var ItemsDataProviderInterface<object>
+     */
     private ItemsDataProviderInterface $itemsDataProvider;
     /**
      * @var FieldHandlerInterface<DataObject>
@@ -51,7 +54,7 @@ abstract class EntityTypeAbstract implements EntityTypeInterface
 
     /**
      * @param EntityRebuildInterface $rebuilder
-     * @param ItemsDataProviderInterface $itemsDataProvider
+     * @param ItemsDataProviderInterface<object> $itemsDataProvider
      * @param FieldHandlerInterface<DataObject> $fieldHandler
      * @param ItemsIndexerInterface $itemsIndexer
      * @param AbstractConfigHelper $configHelper

--- a/Model/Indexing/EntityTypeInterface.php
+++ b/Model/Indexing/EntityTypeInterface.php
@@ -42,6 +42,9 @@ interface EntityTypeInterface
 
     public function getRebuilder(): EntityRebuildInterface;
 
+    /**
+     * @return ItemsDataProviderInterface<object>
+     */
     public function getItemsDataProvider(): ItemsDataProviderInterface;
 
     public function getItemsIndexer(): ItemsIndexerInterface;
@@ -56,6 +59,6 @@ interface EntityTypeInterface
     /*public function getFieldHandler() : FieldHandlerInterface<DataObject>;*/
 
     public function getConfigHelper(): AbstractConfigHelper;
-    
+
     /*public function getFieldNameProvider(): FieldNameProviderInterface;*/
 }

--- a/Model/Indexing/EntityTypeInterface.php
+++ b/Model/Indexing/EntityTypeInterface.php
@@ -22,16 +22,13 @@ use Magento\Framework\DataObject;
  * @api
  * @since 0.8.0
  *
- * @method FieldHandlerInterface<DataObject> getFieldHandler() Use this method in your class implementations for smooth transitions
- *          since 0.10.0. Method will be added in 0.10.0
+ * @method FieldHandlerInterface<DataObject> getFieldHandler() Use this method in your class implementations for smooth
+ *     transitions since 0.10.0. Method will be added in 0.10.0
  * @method FieldNameProviderInterface getFieldNameProvider() Method will be added in 0.10.0
  */
 interface EntityTypeInterface
 {
-    /**
-     * @return string
-     */
-    public function getTypeName() : string;
+    public function getTypeName(): string;
 
     /**
      * @return $this
@@ -43,41 +40,22 @@ interface EntityTypeInterface
      */
     public function getUniqueId(string $itemId);
 
-    /**
-     * @return EntityRebuildInterface
-     */
-    public function getRebuilder() : EntityRebuildInterface;
+    public function getRebuilder(): EntityRebuildInterface;
 
-    /**
-     * @return ItemsDataProviderInterface
-     */
-    public function getItemsDataProvider() : ItemsDataProviderInterface;
+    public function getItemsDataProvider(): ItemsDataProviderInterface;
 
-    /**
-     * @return ItemsIndexerInterface
-     */
-    public function getItemsIndexer() : ItemsIndexerInterface;
+    public function getItemsIndexer(): ItemsIndexerInterface;
 
     /**
      * @deprecated 0.7.0 in favour of a new Field Handlers logic
      * @see self::getFieldHandler()
-     * @return AttributeHandlerInterface|FieldHandlerInterface
      * @phpstan-ignore-next-line
      */
-    public function getAttributeHandler() : FieldHandlerInterface;
+    public function getAttributeHandler(): FieldHandlerInterface;
 
-    /**
-     * @return FieldHandlerInterface<DataObject>
-     */
-    /*public function getFieldHandler() : FieldHandlerInterface;*/
+    /*public function getFieldHandler() : FieldHandlerInterface<DataObject>;*/
 
-    /**
-     * @return AbstractConfigHelper
-     */
-    public function getConfigHelper() : AbstractConfigHelper;
-
-    /**
-     * @return FieldNameProviderInterface
-     */
+    public function getConfigHelper(): AbstractConfigHelper;
+    
     /*public function getFieldNameProvider(): FieldNameProviderInterface;*/
 }

--- a/Model/Indexing/ItemsDataProviderInterface.php
+++ b/Model/Indexing/ItemsDataProviderInterface.php
@@ -18,6 +18,8 @@ namespace HawkSearch\EsIndexing\Model\Indexing;
 /**
  * @api
  * @since 0.8.0
+ *
+ * @template T of object
  */
 interface ItemsDataProviderInterface
 {
@@ -26,7 +28,7 @@ interface ItemsDataProviderInterface
      * @param array<int>|null $entityIds
      * @param int $currentPage
      * @param int $pageSize
-     * @return array
+     * @return T[]
      * @todo $entityIds: default value null -> []
      * @todo $entityIds: change type ?array -> array
      */

--- a/Model/LandingPageManagement.php
+++ b/Model/LandingPageManagement.php
@@ -55,7 +55,7 @@ class LandingPageManagement implements LandingPageManagementInterface
     }
 
     /**
-     * @return array<mixed>
+     * @return list<string>
      * @throws InstructionException
      * @throws NotFoundException
      */

--- a/Model/Layout/ConfigProcessor/JsGlobal/CatalogConfigProcessor.php
+++ b/Model/Layout/ConfigProcessor/JsGlobal/CatalogConfigProcessor.php
@@ -97,6 +97,12 @@ class CatalogConfigProcessor implements LayoutConfigProcessorInterface
         return $this->categoryUrlPathGenerator->getUrlPath($this->getCurrentCategory()) . '/' . '${ $.product_url_slug }';
     }
 
+    /**
+     * @return array{}|array{
+     *     "productUrlRewriteExceptions": array<int, string>,
+     *     "noUrlRewriteProducts": list<int>,
+     * }
+     */
     private function getUrlRewritesConfig(): array
     {
         $category = $this->getCurrentCategory();

--- a/Model/Layout/ConfigProcessor/JsGlobal/CatalogConfigProcessor.php
+++ b/Model/Layout/ConfigProcessor/JsGlobal/CatalogConfigProcessor.php
@@ -72,9 +72,6 @@ class CatalogConfigProcessor implements LayoutConfigProcessorInterface
         return array_merge_recursive($jsConfig, $config);
     }
 
-    /**
-     * @return bool
-     */
     private function isCategoryPage(): bool
     {
         $category = $this->getCurrentCategory();
@@ -90,25 +87,16 @@ class CatalogConfigProcessor implements LayoutConfigProcessorInterface
         return true;
     }
 
-    /**
-     * @return CategoryInterface
-     */
     private function getCurrentCategory(): CategoryInterface
     {
         return $this->currentCategory->get();
     }
 
-    /**
-     * @return string
-     */
     private function getProductUrlTemplate(): string
     {
         return $this->categoryUrlPathGenerator->getUrlPath($this->getCurrentCategory()) . '/' . '${ $.product_url_slug }';
     }
 
-    /**
-     * @return array
-     */
     private function getUrlRewritesConfig(): array
     {
         $category = $this->getCurrentCategory();
@@ -147,17 +135,11 @@ class CatalogConfigProcessor implements LayoutConfigProcessorInterface
         ];
     }
 
-    /**
-     * @return string
-     */
     private function getCategoryUrlPath(): string
     {
         return $this->categoryUrlPathGenerator->getUrlPath($this->getCurrentCategory()) . '/';
     }
 
-    /**
-     * @return bool
-     */
     private function useCategoryPathInProductUrl(): bool
     {
         return $this->scopeConfig->isSetFlag(

--- a/Model/Layout/ConfigProcessor/Vue/VueAdditionalParametersProcessor.php
+++ b/Model/Layout/ConfigProcessor/Vue/VueAdditionalParametersProcessor.php
@@ -99,7 +99,7 @@ class VueAdditionalParametersProcessor implements LayoutConfigProcessorInterface
             return null;
         }
 
-        /** @var Category $category */
+        /** @var ?Category $category */
         $category = $this->registry->registry('current_category');
         if (!$category) {
             return null;

--- a/Model/MessageQueue/RetryBulkManagement.php
+++ b/Model/MessageQueue/RetryBulkManagement.php
@@ -73,7 +73,6 @@ class RetryBulkManagement implements BulkManagementInterface
      * Publish list of operations to the corresponding message queues.
      *
      * @param OperationInterface[] $operations
-     * @return void
      */
     private function publishOperations(array $operations): void
     {

--- a/Model/Product.php
+++ b/Model/Product.php
@@ -43,20 +43,18 @@ class Product
     private ?array $productAllTypes = null;
     private ProductFactory $productFactory;
     private Type $productType;
-    private FulltextResource $fulltextResource;
     private ProductResource $productResource;
     private MetadataPool $metadataPool;
 
     public function __construct(
         ProductFactory $productFactory,
         Type $productType,
-        FulltextResource $fulltextResource,
+        FulltextResource $fulltextResource, // @todo remove $fulltextResource argument
         ProductResource $productResource = null,
         MetadataPool $metadataPool = null
     ) {
         $this->productFactory = $productFactory;
         $this->productType = $productType;
-        $this->fulltextResource = $fulltextResource;
         $this->productResource = $productResource ?: ObjectManager::getInstance()->get(ProductResource::class);
         $this->metadataPool = $metadataPool ?: ObjectManager::getInstance()->get(MetadataPool::class);
     }

--- a/Model/Product.php
+++ b/Model/Product.php
@@ -46,15 +46,14 @@ class Product
     private FulltextResource $fulltextResource;
     private ProductResource $productResource;
     private MetadataPool $metadataPool;
-    
+
     public function __construct(
         ProductFactory $productFactory,
         Type $productType,
         FulltextResource $fulltextResource,
         ProductResource $productResource = null,
         MetadataPool $metadataPool = null
-    )
-    {
+    ) {
         $this->productFactory = $productFactory;
         $this->productType = $productType;
         $this->fulltextResource = $fulltextResource;
@@ -96,7 +95,7 @@ class Product
 
     /**
      * @param int[] $ids
-     * @return array
+     * @return int[]
      * @throws Exception
      */
     public function getParentProductIds(array $ids): array
@@ -117,7 +116,7 @@ class Product
      * from the catalog_product_relation table.
      *
      * @param int[] $childIds
-     * @return array
+     * @return array<int, int[]>|array{}
      * @throws Exception
      */
     public function getParentsByChildMap(array $childIds): array
@@ -143,8 +142,8 @@ class Product
 
         $map = [];
         foreach ($rows as $row) {
-            $map[$row['child_id']] = $map[$row['child_id']] ?? [];
-            $map[$row['child_id']][] = $row['entity_id'];
+            $map[(int)$row['child_id']] = $map[$row['child_id']] ?? [];
+            $map[(int)$row['child_id']][] = (int)$row['entity_id'];
         }
 
         return $map;
@@ -157,7 +156,7 @@ class Product
      * from the catalog_product_relation table.
      *
      * @param int[] $parentIds
-     * @return array
+     * @return array<int, int[]>|array{}
      * @throws Exception
      */
     public function getChildrenByParentMap(array $parentIds): array
@@ -183,8 +182,8 @@ class Product
 
         $map = [];
         foreach ($rows as $row) {
-            $map[$row['entity_id']] = $map[$row['entity_id']] ?? [];
-            $map[$row['entity_id']][] = $row['child_id'];
+            $map[(int)$row['entity_id']] = $map[$row['entity_id']] ?? [];
+            $map[(int)$row['entity_id']][] = (int)$row['child_id'];
         }
 
         return $map;

--- a/Model/Product/Attribute/ExcludeNotVisibleProductsFlagInterface.php
+++ b/Model/Product/Attribute/ExcludeNotVisibleProductsFlagInterface.php
@@ -22,8 +22,5 @@ namespace HawkSearch\EsIndexing\Model\Product\Attribute;
  */
 interface ExcludeNotVisibleProductsFlagInterface
 {
-    /**
-     * @return bool
-     */
     public function execute(): bool;
 }

--- a/Model/Product/Attributes.php
+++ b/Model/Product/Attributes.php
@@ -18,6 +18,7 @@ namespace HawkSearch\EsIndexing\Model\Product;
 use HawkSearch\EsIndexing\Model\Config\Products as ProductsConfig;
 use Magento\Catalog\Model\Product;
 use Magento\Eav\Model\Config;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Serialize\Serializer\Json;
 
 /**
@@ -46,8 +47,8 @@ class Attributes
     }
 
     /**
-     * @return array
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @return array<string, string>
+     * @throws LocalizedException
      */
     public function getAllAttributes()
     {
@@ -75,7 +76,7 @@ class Attributes
      * Returns list of product attributes which should be skipped by indexing processor.
      * Attributes from this list are excluded from any visual interfaces.
      *
-     * @return array
+     * @return list<string>
      */
     public function getExcludedAttributes()
     {
@@ -83,7 +84,7 @@ class Attributes
     }
 
     /**
-     * @return array
+     * @return list<string>
      */
     public function getMandatoryAttributes()
     {
@@ -91,7 +92,7 @@ class Attributes
     }
 
     /**
-     * @return array
+     * @return array<string, string>
      */
     public function getMandatoryFieldMap()
     {
@@ -111,7 +112,7 @@ class Attributes
     /**
      * Product data which is calculated
      *
-     * @return array
+     * @return list<string>
      */
     public function getExtraDataCodes()
     {
@@ -119,7 +120,7 @@ class Attributes
     }
 
     /**
-     * @return array
+     * @return array<string, string>
      */
     public function getIndexedAttributes()
     {
@@ -130,7 +131,7 @@ class Attributes
      * Return mapping hash.
      * Keys of the hash represent fields, values represent attributes.
      *
-     * @return array
+     * @return array<string, string>
      */
     public function getFieldToAttributeMap(): array
     {

--- a/Model/Product/Attributes.php
+++ b/Model/Product/Attributes.php
@@ -120,7 +120,7 @@ class Attributes
     }
 
     /**
-     * @return array<string, string>
+     * @return list<string>
      */
     public function getIndexedAttributes()
     {

--- a/Model/Product/Field/Handler/Composite.php
+++ b/Model/Product/Field/Handler/Composite.php
@@ -73,7 +73,7 @@ class Composite extends FieldHandler\Composite
 
         /** @var ProductResource $productResource */
         $productResource = $item->getResource();
-        /** @var AttributeResource $attributeResource */
+        /** @var AttributeResource|false $attributeResource */
         $attributeResource = $productResource->getAttribute($fieldName);
 
         if ($attributeResource) {

--- a/Model/Product/Field/Handler/DefaultHandler.php
+++ b/Model/Product/Field/Handler/DefaultHandler.php
@@ -60,9 +60,6 @@ class DefaultHandler implements FieldHandlerInterface
         return $value;
     }
 
-    /**
-     * @return string
-     */
     private function getAttributeCodeByFieldName(string $fieldName): string
     {
         return $this->productAttributes->getFieldToAttributeMap()[$fieldName] ?? '';

--- a/Model/Product/Field/Handler/Url.php
+++ b/Model/Product/Field/Handler/Url.php
@@ -24,13 +24,12 @@ use Magento\Store\Model\StoreManagerInterface;
  */
 class Url implements FieldHandlerInterface
 {
-    private StoreManagerInterface $storeManager;
-
+    /**
+     * @todo remove $storeManager argument
+     */
     public function __construct(
         StoreManagerInterface $storeManager
-    ) {
-        $this->storeManager = $storeManager;
-    }
+    ) {}
 
     /**
      * @return string

--- a/Model/Product/ProductType/DefaultType.php
+++ b/Model/Product/ProductType/DefaultType.php
@@ -90,7 +90,6 @@ abstract class DefaultType implements ProductTypeInterface
 
     /**
      * @param ProductModel $product
-     * @return float
      */
     protected function getPriceRegular(ProductInterface $product): float
     {
@@ -99,7 +98,6 @@ abstract class DefaultType implements ProductTypeInterface
 
     /**
      * @param ProductModel $product
-     * @return float
      */
     protected function getPriceFinal(ProductInterface $product): float
     {
@@ -108,7 +106,6 @@ abstract class DefaultType implements ProductTypeInterface
 
     /**
      * @param ProductModel $product
-     * @return float
      */
     protected function getPriceMin(ProductInterface $product): float
     {
@@ -117,7 +114,6 @@ abstract class DefaultType implements ProductTypeInterface
 
     /**
      * @param ProductModel $product
-     * @return float
      */
     protected function getPriceMax(ProductInterface $product): float
     {
@@ -230,7 +226,6 @@ abstract class DefaultType implements ProductTypeInterface
      * @param ProductModel $product
      * @param float $price
      * @param bool $forceIncludeTax
-     * @return float
      */
     protected function handleTax(ProductInterface $product, float $price, bool $forceIncludeTax = false): float
     {
@@ -289,7 +284,6 @@ abstract class DefaultType implements ProductTypeInterface
     }
 
     /**
-     * @return int|null
      * @throws LocalizedException
      */
     protected function getAllCustomerGroupsId(): ?int

--- a/Observer/LayoutUpdateHandler.php
+++ b/Observer/LayoutUpdateHandler.php
@@ -49,6 +49,9 @@ class LayoutUpdateHandler implements ObserverInterface
         $layout->getUpdate()->addHandle($handles);
     }
 
+    /**
+     * @return list<string>
+     */
     private function getResultsHandles(string $action): array
     {
         $allowedActions = [
@@ -77,7 +80,7 @@ class LayoutUpdateHandler implements ObserverInterface
 
         return $handles;
     }
-    
+
     private function isCategoriesEnabled(): bool
     {
         //@todo replace with \HawkSearch\EsIndexing\Registry\CurrentCategory::get()

--- a/Observer/TrackSaleEventOnOrderSuccessObserver.php
+++ b/Observer/TrackSaleEventOnOrderSuccessObserver.php
@@ -41,7 +41,7 @@ class TrackSaleEventOnOrderSuccessObserver implements ObserverInterface
 
         $orderIds = (array)$observer->getEvent()->getData('order_ids');
 
-        /** @var TrackingBlock $block */
+        /** @var TrackingBlock|false $block */
         $block = $this->layout->getBlock('hawksearch.esindexing.eventtracking');
         if ($block) {
             $block->setData('order_ids', $orderIds);

--- a/Plugin/CatalogSearch/ResultIndexPlugin.php
+++ b/Plugin/CatalogSearch/ResultIndexPlugin.php
@@ -41,7 +41,6 @@ class ResultIndexPlugin
     /**
      * @param Index $subject
      * @param null $result
-     * @return void
      */
     public function afterExecute(Index $subject, $result): void
     {

--- a/Plugin/Checkout/CustomerData/Cart.php
+++ b/Plugin/Checkout/CustomerData/Cart.php
@@ -58,7 +58,6 @@ class Cart
     /**
      * Get active quote
      *
-     * @return ?Quote
      * @throws LocalizedException
      * @throws NoSuchEntityException
      * @todo change return type: ?Quote -> Quote
@@ -77,7 +76,6 @@ class Cart
      *
      * @param int $id
      * @param QuoteItem[] $itemsHaystack
-     * @return QuoteItem | null
      * @todo make private
      */
     private function findItemById(int $id, array $itemsHaystack): ?QuoteItem

--- a/Plugin/Eav/Entity/Attribute/Source/Table/SpecificOptionsPlugin.php
+++ b/Plugin/Eav/Entity/Attribute/Source/Table/SpecificOptionsPlugin.php
@@ -30,7 +30,7 @@ class SpecificOptionsPlugin
      * @param callable $proceed
      * @param list<int>|string $ids
      * @param bool $withEmpty
-     * @return array
+     * @return list<array{label: string, value: ?string}>
      * @noinspection PhpMissingParamTypeInspection
      */
     public function aroundGetSpecificOptions(Table $subject, callable $proceed, $ids, bool $withEmpty = true): array
@@ -63,9 +63,9 @@ class SpecificOptionsPlugin
     }
 
     /**
-     * @param list<array{label: string, value: string}> $options
+     * @param list<array{label: string, value: ?string}> $options
      * @param array{label: '', value: ''} $emptyOption
-     * @return array
+     * @return list<array{label: string, value: ?string}>
      * @noinspection PhpMissingParamTypeInspection
      */
     private function addEmptyOption(array $options, array $emptyOption): array

--- a/Plugin/Gateway/Http/TransferIdBuilderPlugin.php
+++ b/Plugin/Gateway/Http/TransferIdBuilderPlugin.php
@@ -18,9 +18,6 @@ use HawkSearch\Connector\Gateway\Http\TransferInterface;
 
 class TransferIdBuilderPlugin
 {
-    /**
-     * @return string
-     */
     public function afterGetUri(TransferInterface $subject, string $result): string
     {
         $openCurlyBracket = str_replace('%', '\%', rawurlencode('{'));

--- a/Plugin/Mview/View/StagingSubscriptionPlugin.php
+++ b/Plugin/Mview/View/StagingSubscriptionPlugin.php
@@ -38,6 +38,7 @@ class StagingSubscriptionPlugin
     }
 
     /**
+     * @return ?array{0: Trigger}
      * @throws \Zend_Db_Exception
      */
     public function beforeSaveTrigger(Subscription $subject, Trigger $trigger): ?array

--- a/Plugin/Quote/OnCartRemoveTrackingEventPlugin.php
+++ b/Plugin/Quote/OnCartRemoveTrackingEventPlugin.php
@@ -48,7 +48,6 @@ class OnCartRemoveTrackingEventPlugin
      * @param Quote $subject
      * @param QuoteItem $result
      * @param int $itemId
-     * @return QuoteItem
      * @throws \Magento\Framework\Exception\RuntimeException
      * @noinspection PhpMissingParamTypeInspection
      */
@@ -65,7 +64,6 @@ class OnCartRemoveTrackingEventPlugin
      * @param Quote $subject
      * @param Quote $result
      * @param int $itemId
-     * @return Quote
      * @throws \Magento\Framework\Exception\RuntimeException
      * @noinspection PhpMissingParamTypeInspection
      */

--- a/Plugin/Store/StoreGroupPlugin.php
+++ b/Plugin/Store/StoreGroupPlugin.php
@@ -45,7 +45,6 @@ class StoreGroupPlugin extends AbstractPlugin
      * @param StoreGroupResourceModel $subject
      * @param StoreGroupResourceModel $result
      * @param StoreGroupModel $group
-     * @return StoreGroupResourceModel
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
@@ -66,7 +65,6 @@ class StoreGroupPlugin extends AbstractPlugin
      * Validate changes for invalidating indexer
      *
      * @param StoreGroupModel $model
-     * @return bool
      */
     protected function validate(AbstractModel $model): bool
     {

--- a/Plugin/Store/StoreViewDisableIndexingPlugin.php
+++ b/Plugin/Store/StoreViewDisableIndexingPlugin.php
@@ -44,7 +44,6 @@ class StoreViewDisableIndexingPlugin
      * @param StoreResourceModel $subject
      * @param StoreResourceModel $result
      * @param Store $store
-     * @return StoreResourceModel
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/Plugin/Store/StoreViewPlugin.php
+++ b/Plugin/Store/StoreViewPlugin.php
@@ -40,9 +40,6 @@ class StoreViewPlugin extends AbstractPlugin
 
     /**
      * Invalidate indexer on store view save
-     *
-     * @return StoreResourceModel
-     *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function afterSave(

--- a/Registry/CurrentCategory.php
+++ b/Registry/CurrentCategory.php
@@ -32,9 +32,6 @@ class CurrentCategory
         $this->category = $categoryFactory->create();
     }
 
-    /**
-     * @return CategoryInterface
-     */
     public function get(): CategoryInterface
     {
         return $this->category;

--- a/Service/DataStorage.php
+++ b/Service/DataStorage.php
@@ -67,6 +67,7 @@ class DataStorage implements DataStorageInterface
         if (isset($this->value)) {
             if (is_object($this->value)
                 && method_exists($this->value, '__destruct')
+                /** @phpstan-ignore booleanAnd.rightAlwaysTrue */
                 && is_callable([$this->value, '__destruct'])) {
                 $this->value->__destruct();
             }

--- a/Service/DataStorageInterface.php
+++ b/Service/DataStorageInterface.php
@@ -23,10 +23,14 @@ use Magento\Framework\Exception\RuntimeException;
 interface DataStorageInterface
 {
     /**
+     * @return void
      * @throws RuntimeException
      */
     public function set(mixed $value, bool $graceful = false);
 
+    /**
+     * @return void
+     */
     public function reset();
 
     /**

--- a/Test/Unit/Block/Adminhtml/System/Config/Product/CustomAttributesTest.php
+++ b/Test/Unit/Block/Adminhtml/System/Config/Product/CustomAttributesTest.php
@@ -436,9 +436,6 @@ class CustomAttributesTest extends TestCase
         ];
     }
 
-    /**
-     * @return void
-     */
     public function testGetAddButtonLabel(): void
     {
         $this->assertEquals("Add New Mapping", $this->block->getAddButtonLabel());

--- a/Ui/Component/DataProvider/BulkDataProvider.php
+++ b/Ui/Component/DataProvider/BulkDataProvider.php
@@ -21,7 +21,7 @@ class BulkDataProvider extends OperationDataProvider
 
     /**
      * @param array<string, mixed> $meta
-     * @return array
+     * @return array<string, mixed>
      */
     public function prepareMeta($meta)
     {


### PR DESCRIPTION
| Q             | A
|---------------| ---
| Branch?       | 0.8 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| BC breaks?    | no
| Tests pass?   | yes
| Tickets       | HC-1703

This PR fixes PHPDoc annotations of array return types to avoid raising phpstan errro "has no value type specified in iterable type array"
Remove redundant `@return` anootations if method already has a type hint defined.
This PR also provided some fixes on types mismatches.