### PR TITLE
refactor: add missing strict types declaration

### DIFF
--- a/Api/Data/LandingPageInterface.php
+++ b/Api/Data/LandingPageInterface.php
@@ -10,6 +10,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Api\Data;
 

--- a/Api/LandingPageManagementInterface.php
+++ b/Api/LandingPageManagementInterface.php
@@ -10,6 +10,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Api;
 

--- a/Api/LandingPageRepositoryInterface.php
+++ b/Api/LandingPageRepositoryInterface.php
@@ -10,6 +10,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Api;
 

--- a/Block/Adminhtml/Bulk/Details/BackButton.php
+++ b/Block/Adminhtml/Bulk/Details/BackButton.php
@@ -10,6 +10,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Block\Adminhtml\Bulk\Details;
 

--- a/Controller/Adminhtml/Bulkoperations/Retry.php
+++ b/Controller/Adminhtml/Bulkoperations/Retry.php
@@ -10,6 +10,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Controller\Adminhtml\Bulkoperations;
 

--- a/Controller/LandingPage/View.php
+++ b/Controller/LandingPage/View.php
@@ -10,6 +10,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Controller\LandingPage;
 

--- a/Controller/LandingPageRouter.php
+++ b/Controller/LandingPageRouter.php
@@ -10,6 +10,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Controller;
 

--- a/Model/Api/SearchCriteria/CollectionProcessor/CustomJoinProcessor.php
+++ b/Model/Api/SearchCriteria/CollectionProcessor/CustomJoinProcessor.php
@@ -10,6 +10,8 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+declare(strict_types=1);
+
 
 namespace HawkSearch\EsIndexing\Model\Api\SearchCriteria\CollectionProcessor;
 

--- a/Model/BulkOperation/Options.php
+++ b/Model/BulkOperation/Options.php
@@ -10,6 +10,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\BulkOperation;
 

--- a/Model/Config/Backend/Serialized/ArraySerialized.php
+++ b/Model/Config/Backend/Serialized/ArraySerialized.php
@@ -10,6 +10,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\Config\Backend\Serialized;
 

--- a/Model/Indexing/Field/DefaultNameProvider.php
+++ b/Model/Indexing/Field/DefaultNameProvider.php
@@ -10,6 +10,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\Indexing\Field;
 

--- a/Model/MessageQueue/BulkPublisher.php
+++ b/Model/MessageQueue/BulkPublisher.php
@@ -10,6 +10,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\MessageQueue;
 

--- a/Model/Product/PriceManagementInterface.php
+++ b/Model/Product/PriceManagementInterface.php
@@ -10,6 +10,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Model\Product;
 

--- a/Model/Product/ProductTypeInterface.php
+++ b/Model/Product/ProductTypeInterface.php
@@ -10,6 +10,8 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+declare(strict_types=1);
+
 namespace HawkSearch\EsIndexing\Model\Product;
 
 use Magento\Catalog\Api\Data\ProductInterface;

--- a/Model/Product/ProductTypePoolInterface.php
+++ b/Model/Product/ProductTypePoolInterface.php
@@ -10,6 +10,8 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+declare(strict_types=1);
+
 namespace HawkSearch\EsIndexing\Model\Product;
 
 /**

--- a/Observer/InitCurrentCategoryObserver.php
+++ b/Observer/InitCurrentCategoryObserver.php
@@ -10,6 +10,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Observer;
 
@@ -26,7 +27,7 @@ class InitCurrentCategoryObserver implements ObserverInterface
     {
         $this->currentCategory = $currentCategory;
     }
-    
+
     public function execute(Observer $observer): void
     {
         /** @var CategoryInterface $category */

--- a/Observer/LayoutUpdateHandler.php
+++ b/Observer/LayoutUpdateHandler.php
@@ -10,6 +10,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Observer;
 

--- a/Ui/Component/Listing/Column/BulkActions.php
+++ b/Ui/Component/Listing/Column/BulkActions.php
@@ -10,6 +10,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+declare(strict_types=1);
 
 namespace HawkSearch\EsIndexing\Ui\Component\Listing\Column;
 


### PR DESCRIPTION
| Q             | A
|---------------| ---
| Branch?       | 0.8 
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| BC breaks?    | no
| Tests pass?   | yes
| Tickets       | 

Fix the missing `declare(strict_types=1)` directive in the file. 
See [Strict typing (php. net)](https://www.php.net/manual/en/language.types.declarations.php#language.types.declarations.strict) to learn more about why you may need use this directive.