### PR TITLE
fix: exception: each method must have a doc block

### DIFF
--- a/Api/Data/BoostQueryInterface.php
+++ b/Api/Data/BoostQueryInterface.php
@@ -22,11 +22,23 @@ interface BoostQueryInterface
     public const FIELD_QUERY = 'Query';
     public const FIELD_BOOST = 'Boost';
 
+    /**
+     * @return string
+     */
     public function getQuery(): string;
 
+    /**
+     * @return $this
+     */
     public function setQuery(?string $value): self;
 
+    /**
+     * @return float
+     */
     public function getBoost(): float;
-    
+
+    /**
+     * @return $this
+     */
     public function setBoost(float $value): self;
 }

--- a/Api/Data/ClientDataInterface.php
+++ b/Api/Data/ClientDataInterface.php
@@ -34,12 +34,24 @@ interface ClientDataInterface
     const FIELD_ORIGIN = 'Origin';
     const FIELD_ZIP_CODE = 'ZipCode';
 
+    /**
+     * @return string
+     */
     public function getVisitorId(): string;
 
+    /**
+     * @return $this
+     */
     public function setVisitorId(?string $value): self;
 
+    /**
+     * @return string
+     */
     public function getVisitId(): string;
 
+    /**
+     * @return $this
+     */
     public function setVisitId(?string $value): self;
 
     /**
@@ -49,6 +61,7 @@ interface ClientDataInterface
 
     /**
      * @param array<string, string>|null $value
+     * @return $this
      */
     public function setCustom(?array $value): self;
 
@@ -59,6 +72,7 @@ interface ClientDataInterface
 
     /**
      * @param array<string, list<string>>|null $value
+     * @return $this
      */
     public function setExtendedCustom(?array $value): self;
 
@@ -69,18 +83,37 @@ interface ClientDataInterface
 
     /**
      * @param list<int>|null $value
+     * @return $this
      */
     public function setPreviewBuckets(?array $value): self;
 
+    /**
+     * @return string
+     */
     public function getSource(): string;
 
+    /**
+     * @return $this
+     */
     public function setSource(?string $value): self;
 
+    /**
+     * @return CoordinateInterface
+     */
     public function getOrigin(): CoordinateInterface;
 
+    /**
+     * @return $this
+     */
     public function setOrigin(?CoordinateInterface $value): self;
 
+    /**
+     * @return string
+     */
     public function getZipCode(): string;
 
+    /**
+     * @return $this
+     */
     public function setZipCode(?string $value): self;
 }

--- a/Api/Data/CoordinateInterface.php
+++ b/Api/Data/CoordinateInterface.php
@@ -27,11 +27,23 @@ interface CoordinateInterface
     const FIELD_LATITUDE = 'Latitude';
     const FIELD_LONGITUDE = 'Longitude';
 
+    /**
+     * @return float
+     */
     public function getLatitude(): float;
 
+    /**
+     * @return $this
+     */
     public function setLatitude(float $value): self;
 
+    /**
+     * @return float
+     */
     public function getLongitude(): float;
 
+    /**
+     * @return $this
+     */
     public function setLongitude(float $value): self;
 }

--- a/Api/Data/EsIndexInterface.php
+++ b/Api/Data/EsIndexInterface.php
@@ -25,6 +25,9 @@ interface EsIndexInterface
 {
     public const INDEX_NAME = 'IndexName';
 
+    /**
+     * @return string|null
+     */
     public function getIndexName(): ?string;
 
     /**

--- a/Api/Data/FacetBoostBuryInterface.php
+++ b/Api/Data/FacetBoostBuryInterface.php
@@ -37,6 +37,7 @@ interface FacetBoostBuryInterface
 
     /**
      * @param FacetValueOrderInfoInterface[]|null $value
+     * @return $this
      */
     public function setBoostValues(?array $value): self;
 
@@ -47,6 +48,7 @@ interface FacetBoostBuryInterface
 
     /**
      * @param FacetValueOrderInfoInterface[]|null $value
+     * @return $this
      */
     public function setBuryValues(?array $value): self;
 }

--- a/Api/Data/FacetInterface.php
+++ b/Api/Data/FacetInterface.php
@@ -72,148 +72,364 @@ interface FacetInterface
     const CURRENCY_SYMBOL = 'CurrencySymbol';
     const DEFAULT_ITEM_TYPE = 'DefaultItemType';
 
+    /**
+     * @return string
+     */
     public function getSyncGuid(): string;
 
+    /**
+     * @return $this
+     */
     public function setSyncGuid(?string $value): self;
 
+    /**
+     * @return int
+     */
     public function getFacetId(): int;
 
+    /**
+     * @return $this
+     */
     public function setFacetId(int $value): self;
 
+    /**
+     * @return string
+     */
     public function getName(): string;
 
+    /**
+     * @return $this
+     */
     public function setName(?string $value): self;
 
+    /**
+     * @return string
+     */
     public function getFacetType(): string;
 
+    /**
+     * @return $this
+     */
     public function setFacetType(?string $value): self;
 
+    /**
+     * @return string
+     */
     public function getFieldType(): string;
 
+    /**
+     * @return $this
+     */
     public function setFieldType(?string $value): self;
 
+    /**
+     * @return int
+     */
     public function getMaxCount(): int;
 
+    /**
+     * @return $this
+     */
     public function setMaxCount(int $value): self;
 
+    /**
+     * @return int
+     */
     public function getMinHitCount(): int;
 
+    /**
+     * @return $this
+     */
     public function setMinHitCount(int $value): self;
 
+    /**
+     * @return string
+     */
     public function getField(): string;
 
+    /**
+     * @return $this
+     */
     public function setField(?string $value): self;
 
+    /**
+     * @return string
+     */
     public function getParam(): string;
 
+    /**
+     * @return $this
+     */
     public function setParam(?string $value): self;
 
+    /**
+     * @return string
+     */
     public function getDisplayType(): string;
 
+    /**
+     * @return $this
+     */
     public function setDisplayType(?string $value): self;
 
+    /**
+     * @return int
+     */
     public function getScrollHeight(): int;
 
+    /**
+     * @return $this
+     */
     public function setScrollHeight(int $value): self;
 
+    /**
+     * @return int
+     */
     public function getScrollThreshold(): int;
 
+    /**
+     * @return $this
+     */
     public function setScrollThreshold(int $value): self;
 
+    /**
+     * @return int
+     */
     public function getTruncateThreshold(): int;
 
+    /**
+     * @return $this
+     */
     public function setTruncateThreshold(int $value): self;
 
+    /**
+     * @return int
+     */
     public function getSearchThreshold(): int;
 
+    /**
+     * @return $this
+     */
     public function setSearchThreshold(int $value): self;
 
+    /**
+     * @return int
+     */
     public function getSortOrder(): int;
 
+    /**
+     * @return $this
+     */
     public function setSortOrder(int $value): self;
 
+    /**
+     * @return bool
+     */
     public function getExpandSelection(): bool;
 
+    /**
+     * @return $this
+     */
     public function setExpandSelection(bool $value): self;
 
+    /**
+     * @return bool
+     */
     public function getIsCurrency(): bool;
 
+    /**
+     * @return $this
+     */
     public function setIsCurrency(bool $value): self;
 
+    /**
+     * @return bool
+     */
     public function getIsNumeric(): bool;
 
+    /**
+     * @return $this
+     */
     public function setIsNumeric(bool $value): self;
 
+    /**
+     * @return bool
+     */
     public function getIsSearch(): bool;
 
+    /**
+     * @return $this
+     */
     public function setIsSearch(bool $value): self;
 
+    /**
+     * @return bool
+     */
     public function getIsVisible(): bool;
 
+    /**
+     * @return $this
+     */
     public function setIsVisible(bool $value): self;
 
+    /**
+     * @return string
+     */
     public function getUBound(): string;
 
+    /**
+     * @return $this
+     */
     public function setUBound(?string $value): self;
 
+    /**
+     * @return string
+     */
     public function getLBound(): string;
 
+    /**
+     * @return $this
+     */
     public function setLBound(?string $value): self;
 
+    /**
+     * @return string
+     */
     public function getIncrement(): string;
 
+    /**
+     * @return $this
+     */
     public function setIncrement(?string $value): self;
 
+    /**
+     * @return int
+     */
     public function getNofVisible(): int;
 
+    /**
+     * @return $this
+     */
     public function setNofVisible(int $value): self;
 
+    /**
+     * @return int
+     */
     public function getHeight(): int;
 
+    /**
+     * @return $this
+     */
     public function setHeight(int $value): self;
 
+    /**
+     * @return string
+     */
     public function getDisplayRuleXML(): string;
 
+    /**
+     * @return $this
+     */
     public function setDisplayRuleXML(?string $value): self;
 
+    /**
+     * @return string
+     */
     public function getSortBy(): string;
 
+    /**
+     * @return $this
+     */
     public function setSortBy(?string $value): self;
 
+    /**
+     * @return int
+     */
     public function getParentId(): int;
 
+    /**
+     * @return $this
+     */
     public function setParentId(int $value): self;
 
+    /**
+     * @return bool
+     */
     public function getIsCollapsible(): bool;
 
+    /**
+     * @return $this
+     */
     public function setIsCollapsible(bool $value): self;
 
+    /**
+     * @return bool
+     */
     public function getIsCollapsedDefault(): bool;
 
+    /**
+     * @return $this
+     */
     public function setIsCollapsedDefault(bool $value): self;
 
+    /**
+     * @return string
+     */
     public function getSwatchData(): string;
 
+    /**
+     * @return $this
+     */
     public function setSwatchData(?string $value): self;
 
+    /**
+     * @return int
+     */
     public function getFacetRangeDisplayType(): int;
 
+    /**
+     * @return $this
+     */
     public function setFacetRangeDisplayType(int $value): self;
 
+    /**
+     * @return bool
+     */
     public function getPreloadChildren(): bool;
 
+    /**
+     * @return $this
+     */
     public function setPreloadChildren(bool $value): self;
 
+    /**
+     * @return string
+     */
     public function getTooltip(): string;
 
+    /**
+     * @return $this
+     */
     public function setTooltip(?string $value): self;
 
+    /**
+     * @return bool
+     */
     public function getShowSliderInputs(): bool;
 
+    /**
+     * @return $this
+     */
     public function setShowSliderInputs(bool $value): self;
 
+    /**
+     * @return bool
+     */
     public function getShowFacetImageCount(): bool;
 
+    /**
+     * @return $this
+     */
     public function setShowFacetImageCount(bool $value): self;
 
     /**
@@ -223,38 +439,87 @@ interface FacetInterface
 
     /**
      * @param FacetRangeModelInterface[]|null $value
+     * @return $this
      */
     public function setFacetRanges(?array $value): self;
 
+    /**
+     * @return string
+     */
     public function getTags(): string;
 
+    /**
+     * @return $this
+     */
     public function setTags(?string $value): self;
 
+    /**
+     * @return string
+     */
     public function getCreateDate(): string;
 
+    /**
+     * @return $this
+     */
     public function setCreateDate(?string $value): self;
 
+    /**
+     * @return string
+     */
     public function getModifyDate(): string;
 
+    /**
+     * @return $this
+     */
     public function setModifyDate(?string $value): self;
 
+    /**
+     * @return FacetBoostBuryInterface
+     */
     public function getBoostBury(): FacetBoostBuryInterface;
-    
+
+    /**
+     * @return $this
+     */
     public function setBoostBury(?FacetBoostBuryInterface $value): self;
 
+    /**
+     * @return string
+     */
     public function getListName(): string;
 
+    /**
+     * @return $this
+     */
     public function setListName(?string $value): self;
 
+    /**
+     * @return int
+     */
     public function getNumericPrecision(): int;
 
+    /**
+     * @return $this
+     */
     public function setNumericPrecision(int $value): self;
 
+    /**
+     * @return string
+     */
     public function getCurrencySymbol(): string;
 
+    /**
+     * @return $this
+     */
     public function setCurrencySymbol(?string $value): self;
 
+    /**
+     * @return string
+     */
     public function getDefaultItemType(): string;
 
+    /**
+     * @return $this
+     */
     public function setDefaultItemType(?string $value): self;
 }

--- a/Api/Data/FacetRangeModelInterface.php
+++ b/Api/Data/FacetRangeModelInterface.php
@@ -35,31 +35,73 @@ interface FacetRangeModelInterface
     const ASSET_NAME = 'AssetName';
     const ASSET_URL = 'AssetUrl';
 
+    /**
+     * @return int
+     */
     public function getRangeId(): int;
 
+    /**
+     * @return $this
+     */
     public function setRangeId(int $value): self;
 
+    /**
+     * @return string
+     */
     public function getName(): string;
 
+    /**
+     * @return $this
+     */
     public function setName(?string $value): self;
 
+    /**
+     * @return string
+     */
     public function getLBound(): string;
 
+    /**
+     * @return $this
+     */
     public function setLBound(?string $value): self;
 
+    /**
+     * @return string
+     */
     public function getUBound(): string;
 
+    /**
+     * @return $this
+     */
     public function setUBound(?string $value): self;
 
+    /**
+     * @return int
+     */
     public function getSortOrder(): int;
 
+    /**
+     * @return $this
+     */
     public function setSortOrder(int $value): self;
 
+    /**
+     * @return string
+     */
     public function getAssetName(): string;
 
+    /**
+     * @return $this
+     */
     public function setAssetName(?string $value): self;
 
+    /**
+     * @return string
+     */
     public function getAssetUrl(): string;
 
+    /**
+     * @return $this
+     */
     public function setAssetUrl(?string $value): self;
 }

--- a/Api/Data/FacetValueOrderInfoInterface.php
+++ b/Api/Data/FacetValueOrderInfoInterface.php
@@ -30,11 +30,23 @@ interface FacetValueOrderInfoInterface
     const VALUE = 'Value';
     const SORT_ORDER = 'SortOrder';
 
+    /**
+     * @return string
+     */
     public function getValue(): string;
 
+    /**
+     * @return $this
+     */
     public function setValue(?string $value): self;
 
+    /**
+     * @return int
+     */
     public function getSortOrder(): int;
 
+    /**
+     * @return $this
+     */
     public function setSortOrder(int $value): self;
 }

--- a/Api/Data/FieldInterface.php
+++ b/Api/Data/FieldInterface.php
@@ -74,144 +74,354 @@ interface FieldInterface
     const FIELD_TYPE_UNINDEXED = 'unindexed';
     const FIELD_TYPE_TEXT = 'text';
 
+    /**
+     * @return int
+     */
     public function getFieldId(): int;
 
+    /**
+     * @return $this
+     */
     public function setFieldId(int $value): self;
 
+    /**
+     * @return string
+     */
     public function getSyncGuid(): string;
 
+    /**
+     * @return $this
+     */
     public function setSyncGuid(?string $value): self;
 
+    /**
+     * @return string
+     */
     public function getLabel(): string;
 
+    /**
+     * @return $this
+     */
     public function setLabel(?string $value): self;
 
+    /**
+     * @return string
+     */
     public function getName(): string;
 
+    /**
+     * @return $this
+     */
     public function setName(?string $value): self;
 
+    /**
+     * @return bool
+     */
     public function getIsPrimaryKey(): bool;
 
+    /**
+     * @return $this
+     */
     public function setIsPrimaryKey(bool $value): self;
 
+    /**
+     * @return string
+     */
     public function getType(): string;
 
+    /**
+     * @return $this
+     */
     public function setType(?string $value): self;
 
+    /**
+     * @return string
+     */
     public function getFieldType(): string;
 
+    /**
+     * @return $this
+     */
     public function setFieldType(?string $value): self;
 
+    /**
+     * @return int
+     */
     public function getBoost(): int;
 
+    /**
+     * @return $this
+     */
     public function setBoost(int $value): self;
 
+    /**
+     * @return int
+     */
     public function getFacetHandler(): int;
 
+    /**
+     * @return $this
+     */
     public function setFacetHandler(int $value): self;
 
+    /**
+     * @return bool
+     */
     public function getIsOutput(): bool;
 
+    /**
+     * @return $this
+     */
     public function setIsOutput(bool $value): self;
 
+    /**
+     * @return bool
+     */
     public function getIsShingle(): bool;
 
+    /**
+     * @return $this
+     */
     public function setIsShingle(bool $value): self;
 
+    /**
+     * @return bool
+     */
     public function getIsBestFragment(): bool;
 
+    /**
+     * @return $this
+     */
     public function setIsBestFragment(bool $value): self;
 
+    /**
+     * @return bool
+     */
     public function getIsDictionary(): bool;
 
+    /**
+     * @return $this
+     */
     public function setIsDictionary(bool $value): self;
 
+    /**
+     * @return bool
+     */
     public function getIsSort(): bool;
 
+    /**
+     * @return $this
+     */
     public function setIsSort(bool $value): self;
 
+    /**
+     * @return bool
+     */
     public function getIsPrefix(): bool;
 
+    /**
+     * @return $this
+     */
     public function setIsPrefix(bool $value): self;
 
+    /**
+     * @return bool
+     */
     public function getIsHidden(): bool;
 
+    /**
+     * @return $this
+     */
     public function setIsHidden(bool $value): self;
 
+    /**
+     * @return bool
+     */
     public function getIsCompare(): bool;
 
+    /**
+     * @return $this
+     */
     public function setIsCompare(bool $value): self;
 
+    /**
+     * @return int
+     */
     public function getSortOrder(): int;
 
+    /**
+     * @return $this
+     */
     public function setSortOrder(int $value): self;
 
+    /**
+     * @return string
+     */
     public function getPartialQuery(): string;
 
+    /**
+     * @return $this
+     */
     public function setPartialQuery(?string $value): self;
 
+    /**
+     * @return bool
+     */
     public function getIsKeywordText(): bool;
 
+    /**
+     * @return $this
+     */
     public function setIsKeywordText(bool $value): self;
 
+    /**
+     * @return bool
+     */
     public function getIsQuery(): bool;
 
+    /**
+     * @return $this
+     */
     public function setIsQuery(bool $value): self;
 
+    /**
+     * @return bool
+     */
     public function getIsQueryText(): bool;
 
+    /**
+     * @return $this
+     */
     public function setIsQueryText(bool $value): self;
 
+    /**
+     * @return bool
+     */
     public function getSkipCustom(): bool;
 
+    /**
+     * @return $this
+     */
     public function setSkipCustom(bool $value): self;
 
+    /**
+     * @return bool
+     */
     public function getStripHtml(): bool;
 
+    /**
+     * @return $this
+     */
     public function setStripHtml(bool $value): self;
 
+    /**
+     * @return int
+     */
     public function getMinNGramAnalyzer(): int;
 
+    /**
+     * @return $this
+     */
     public function setMinNGramAnalyzer(int $value): self;
 
+    /**
+     * @return int
+     */
     public function getMaxNGramAnalyzer(): int;
 
+    /**
+     * @return $this
+     */
     public function setMaxNGramAnalyzer(int $value): self;
 
+    /**
+     * @return int
+     */
     public function getCoordinateType(): int;
 
+    /**
+     * @return $this
+     */
     public function setCoordinateType(int $value): self;
 
+    /**
+     * @return bool
+     */
     public function getOmitNorms(): bool;
 
+    /**
+     * @return $this
+     */
     public function setOmitNorms(bool $value): self;
 
+    /**
+     * @return string
+     */
     public function getItemMapping(): string;
 
+    /**
+     * @return $this
+     */
     public function setItemMapping(?string $value): self;
 
+    /**
+     * @return string
+     */
     public function getDefaultValue(): string;
 
+    /**
+     * @return $this
+     */
     public function setDefaultValue(?string $value): self;
 
+    /**
+     * @return bool
+     */
     public function getUseForPrediction(): bool;
 
+    /**
+     * @return $this
+     */
     public function setUseForPrediction(bool $value): self;
 
+    /**
+     * @return string
+     */
     public function getCopyTo(): string;
 
+    /**
+     * @return $this
+     */
     public function setCopyTo(?string $value): self;
 
+    /**
+     * @return string
+     */
     public function getAnalyzer(): string;
 
+    /**
+     * @return $this
+     */
     public function setAnalyzer(?string $value): self;
 
+    /**
+     * @return bool
+     */
     public function getDoNotStore(): bool;
 
+    /**
+     * @return $this
+     */
     public function setDoNotStore(bool $value): self;
 
+    /**
+     * @return string
+     */
     public function getTags(): string;
 
+    /**
+     * @return $this
+     */
     public function setTags(?string $value): self;
 
     /**
@@ -221,34 +431,77 @@ interface FieldInterface
 
     /**
      * @param int[]|null $value
+     * @return $this
      */
     public function setIterations(?array $value): self;
 
+    /**
+     * @return string
+     */
     public function getAnalyzerLanguage(): string;
 
+    /**
+     * @return $this
+     */
     public function setAnalyzerLanguage(?string $value): self;
 
+    /**
+     * @return string
+     */
     public function getPreviewMapping(): string;
 
+    /**
+     * @return $this
+     */
     public function setPreviewMapping(?string $value): self;
 
+    /**
+     * @return bool
+     */
     public function getOmitTfAndPos(): bool;
 
+    /**
+     * @return $this
+     */
     public function setOmitTfAndPos(bool $value): self;
 
+    /**
+     * @return string
+     */
     public function getCreateDate(): string;
 
+    /**
+     * @return $this
+     */
     public function setCreateDate(?string $value): self;
 
+    /**
+     * @return string
+     */
     public function getModifyDate(): string;
 
+    /**
+     * @return $this
+     */
     public function setModifyDate(?string $value): self;
 
+    /**
+     * @return bool
+     */
     public function getIsChild(): bool;
 
+    /**
+     * @return $this
+     */
     public function setIsChild(bool $value): self;
 
+    /**
+     * @return bool
+     */
     public function getIsHierarchical(): bool;
 
+    /**
+     * @return $this
+     */
     public function setIsHierarchical(bool $value): self;
 }

--- a/Api/Data/HierarchyInterface.php
+++ b/Api/Data/HierarchyInterface.php
@@ -33,6 +33,9 @@ interface HierarchyInterface
     public const FIELD_SORTORDER = "SortOrder";
     public const FIELD_CUSTOM = "Custom";
 
+    /**
+     * @return string
+     */
     public function getHierarchyId(): string;
 
     /**
@@ -40,6 +43,9 @@ interface HierarchyInterface
      */
     public function setHierarchyId(string $value);
 
+    /**
+     * @return string
+     */
     public function getName(): string;
 
     /**
@@ -47,6 +53,9 @@ interface HierarchyInterface
      */
     public function setName(string $value);
 
+    /**
+     * @return string
+     */
     public function getParentHierarchyId(): string;
 
     /**
@@ -54,6 +63,9 @@ interface HierarchyInterface
      */
     public function setParentHierarchyId(string $value);
 
+    /**
+     * @return bool
+     */
     public function getIsActive(): bool;
 
     /**
@@ -61,6 +73,9 @@ interface HierarchyInterface
      */
     public function setIsActive(bool $value);
 
+    /**
+     * @return int
+     */
     public function getSortOrder(): int;
 
     /**
@@ -68,6 +83,9 @@ interface HierarchyInterface
      */
     public function setSortOrder(int $value);
 
+    /**
+     * @return string
+     */
     public function getCustom(): string;
 
     /**

--- a/Api/Data/IndexItemsContextInterface.php
+++ b/Api/Data/IndexItemsContextInterface.php
@@ -27,8 +27,14 @@ interface IndexItemsContextInterface
     public const FIELD_INDEX_NAME = 'IndexName';
     public const FIELD_ITEMS = 'Items';
 
+    /**
+     * @return string
+     */
     public function getIndexName(): string;
 
+    /**
+     * @return $this
+     */
     public function setIndexName(?string $value): self;
 
     /**
@@ -38,6 +44,7 @@ interface IndexItemsContextInterface
 
     /**
      * @param IndexItemInterface[]|null $value
+     * @return $this
      */
     public function setItems(?array $value): self;
 }

--- a/Api/Data/LandingPageInterface.php
+++ b/Api/Data/LandingPageInterface.php
@@ -55,6 +55,9 @@ interface LandingPageInterface
     public const FIELD_IS_NO_FOLLOW = "IsNoFollow";
     public const FIELD_CUSTOM_SORT_LIST = "CustomSortList";
 
+    /**
+     * @return int|null
+     */
     public function getPageId(): ?int;
 
     /**
@@ -62,6 +65,9 @@ interface LandingPageInterface
      */
     public function setPageId(?int $value);
 
+    /**
+     * @return string|null
+     */
     public function getSyncGuid(): ?string;
 
     /**
@@ -69,6 +75,9 @@ interface LandingPageInterface
      */
     public function setSyncGuid(?string $value);
 
+    /**
+     * @return string|null
+     */
     public function getName(): ?string;
 
     /**
@@ -76,6 +85,9 @@ interface LandingPageInterface
      */
     public function setName(?string $value);
 
+    /**
+     * @return string|null
+     */
     public function getCustomUrl(): ?string;
 
     /**
@@ -83,6 +95,9 @@ interface LandingPageInterface
      */
     public function setCustomUrl(?string $value);
 
+    /**
+     * @return string|null
+     */
     public function getNarrowXml(): ?string;
 
     /**
@@ -90,6 +105,9 @@ interface LandingPageInterface
      */
     public function setNarrowXml(?string $value);
 
+    /**
+     * @return bool
+     */
     public function getIsFacetOverride(): bool;
 
     /**
@@ -97,6 +115,9 @@ interface LandingPageInterface
      */
     public function setIsFacetOverride(bool $value);
 
+    /**
+     * @return bool
+     */
     public function getIsIncludeProducts(): bool;
 
     /**
@@ -104,6 +125,9 @@ interface LandingPageInterface
      */
     public function setIsIncludeProducts(bool $value);
 
+    /**
+     * @return string|null
+     */
     public function getSortFieldId(): ?string;
 
     /**
@@ -111,6 +135,9 @@ interface LandingPageInterface
      */
     public function setSortFieldId(?string $value);
 
+    /**
+     * @return string|null
+     */
     public function getSortDirection(): ?string;
 
     /**
@@ -129,6 +156,9 @@ interface LandingPageInterface
      */
     public function setSelectedFacets(array $value);
 
+    /**
+     * @return string|null
+     */
     public function getPageLayoutId(): ?string;
 
     /**
@@ -136,6 +166,9 @@ interface LandingPageInterface
      */
     public function setPageLayoutId(?string $value);
 
+    /**
+     * @return bool
+     */
     public function getEnableFacetAutoOrdering(): bool;
 
     /**
@@ -143,6 +176,9 @@ interface LandingPageInterface
      */
     public function setEnableFacetAutoOrdering(bool $value);
 
+    /**
+     * @return string|null
+     */
     public function getCustom(): ?string;
 
     /**
@@ -150,6 +186,9 @@ interface LandingPageInterface
      */
     public function setCustom(?string $value);
 
+    /**
+     * @return string|null
+     */
     public function getTags(): ?string;
 
     /**
@@ -157,6 +196,9 @@ interface LandingPageInterface
      */
     public function setTags(?string $value);
 
+    /**
+     * @return string|null
+     */
     public function getCanonicalUrl(): ?string;
 
     /**
@@ -164,6 +206,9 @@ interface LandingPageInterface
      */
     public function setCanonicalUrl(?string $value);
 
+    /**
+     * @return string|null
+     */
     public function getPageType(): ?string;
 
     /**
@@ -182,6 +227,9 @@ interface LandingPageInterface
      */
     public function setContentConfigList(array $value);
 
+    /**
+     * @return string|null
+     */
     public function getPageHeading(): ?string;
 
     /**
@@ -189,6 +237,9 @@ interface LandingPageInterface
      */
     public function setPageHeading(?string $value);
 
+    /**
+     * @return string|null
+     */
     public function getCustomHtml(): ?string;
 
     /**
@@ -196,6 +247,9 @@ interface LandingPageInterface
      */
     public function setCustomHtml(?string $value);
 
+    /**
+     * @return string|null
+     */
     public function getKeywords(): ?string;
 
     /**
@@ -203,6 +257,9 @@ interface LandingPageInterface
      */
     public function setKeywords(?string $value);
 
+    /**
+     * @return string|null
+     */
     public function getListName(): ?string;
 
     /**
@@ -210,6 +267,9 @@ interface LandingPageInterface
      */
     public function setListName(?string $value);
 
+    /**
+     * @return string|null
+     */
     public function getNotes(): ?string;
 
     /**
@@ -217,6 +277,9 @@ interface LandingPageInterface
      */
     public function setNotes(?string $value);
 
+    /**
+     * @return string|null
+     */
     public function getCreateDate(): ?string;
 
     /**
@@ -224,6 +287,9 @@ interface LandingPageInterface
      */
     public function setCreateDate(?string $value);
 
+    /**
+     * @return string|null
+     */
     public function getModifyDate(): ?string;
 
     /**
@@ -231,6 +297,9 @@ interface LandingPageInterface
      */
     public function setModifyDate(?string $value);
 
+    /**
+     * @return bool
+     */
     public function getIsNoIndex(): bool;
 
     /**
@@ -238,6 +307,9 @@ interface LandingPageInterface
      */
     public function setIsNoIndex(bool $value);
 
+    /**
+     * @return bool
+     */
     public function getIsNoFollow(): bool;
 
     /**
@@ -245,6 +317,9 @@ interface LandingPageInterface
      */
     public function setIsNoFollow(bool $value);
 
+    /**
+     * @return string|null
+     */
     public function getCustomSortList(): ?string;
 
     /**

--- a/Api/Data/SearchRequestInterface.php
+++ b/Api/Data/SearchRequestInterface.php
@@ -55,18 +55,36 @@ interface SearchRequestInterface
     public const FIELD_SEARCH_TYPE = 'SearchType';
     public const FIELD_IGNORE_SPELLCHECK = 'IgnoreSpellcheck';
 
+    /**
+     * @return string
+     */
     public function getIndexName(): string;
 
+    /**
+     * @return $this
+     */
     public function setIndexName(?string $value): self;
 
+    /**
+     * @return string
+     */
     public function getQuery(): string;
 
+    /**
+     * @return $this
+     */
     public function setQuery(?string $value): self;
 
 
+    /**
+     * @return VariantOptionsInterface
+     */
     public function getVariant(): VariantOptionsInterface;
 
 
+    /**
+     * @return $this
+     */
     public function setVariant(?VariantOptionsInterface $value): self;
 
     /**
@@ -76,63 +94,148 @@ interface SearchRequestInterface
 
     /**
      * @param BoostQueryInterface[]|null $value
+     * @return $this
      */
     public function setBoostQueries(?array $value): self;
 
+    /**
+     * @return int
+     */
     public function getDistanceUnitType(): int;
 
+    /**
+     * @return $this
+     */
     public function setDistanceUnitType(int $value): self;
 
+    /**
+     * @return int
+     */
     public function getRequestType(): int;
 
+    /**
+     * @return $this
+     */
     public function setRequestType(int $value): self;
 
+    /**
+     * @return string
+     */
     public function getImageData(): string;
 
+    /**
+     * @return $this
+     */
     public function setImageData(?string $value): self;
 
+    /**
+     * @return string
+     */
     public function getImageText(): string;
 
+    /**
+     * @return $this
+     */
     public function setImageText(?string $value): self;
 
+    /**
+     * @return int
+     */
     public function getKValue(): int;
 
+    /**
+     * @return $this
+     */
     public function setKValue(int $value): self;
 
+    /**
+     * @return string
+     */
     public function getClientGuid(): string;
 
+    /**
+     * @return $this
+     */
     public function setClientGuid(?string $value): self;
 
+    /**
+     * @return string
+     */
     public function getKeyword(): string;
 
+    /**
+     * @return $this
+     */
     public function setKeyword(?string $value): self;
 
+    /**
+     * @return int
+     */
     public function getPageId(): int;
 
+    /**
+     * @return $this
+     */
     public function setPageId(int $value): self;
 
+    /**
+     * @return int
+     */
     public function getPageNo(): int;
 
+    /**
+     * @return $this
+     */
     public function setPageNo(int $value): self;
 
+    /**
+     * @return int
+     */
     public function getMaxPerPage(): int;
 
+    /**
+     * @return $this
+     */
     public function setMaxPerPage(int $value): self;
 
+    /**
+     * @return string
+     */
     public function getSearchWithin(): string;
 
+    /**
+     * @return $this
+     */
     public function setSearchWithin(?string $value): self;
 
+    /**
+     * @return string
+     */
     public function getSortBy(): string;
 
+    /**
+     * @return $this
+     */
     public function setSortBy(?string $value): self;
 
+    /**
+     * @return string
+     */
     public function getSortingSetCode(): string;
 
+    /**
+     * @return $this
+     */
     public function setSortingSetCode(?string $value): self;
 
+    /**
+     * @return string
+     */
     public function getPaginationSetCode(): string;
 
+    /**
+     * @return $this
+     */
     public function setPaginationSetCode(?string $value): self;
 
     /**
@@ -142,23 +245,48 @@ interface SearchRequestInterface
 
     /**
      * @param array<string, list<array<string, string>>>|null $value
+     * @return $this
      */
     public function setFacetSelections(?array $value): self;
 
+    /**
+     * @return string
+     */
     public function getCustomUrl(): string;
 
+    /**
+     * @return $this
+     */
     public function setCustomUrl(?string $value): self;
 
+    /**
+     * @return bool
+     */
     public function getIsInPreview(): bool;
 
+    /**
+     * @return $this
+     */
     public function setIsInPreview(bool $value): self;
 
+    /**
+     * @return bool
+     */
     public function getIs100CoverageTurnedOn(): bool;
 
+    /**
+     * @return $this
+     */
     public function setIs100CoverageTurnedOn(bool $value): self;
 
+    /**
+     * @return string
+     */
     public function getExplainDocId(): string;
 
+    /**
+     * @return $this
+     */
     public function setExplainDocId(?string $value): self;
 
     /**
@@ -168,6 +296,7 @@ interface SearchRequestInterface
 
     /**
      * @param string[]|null $value
+     * @return $this
      */
     public function setFacetOverride(?array $value): self;
 
@@ -178,22 +307,47 @@ interface SearchRequestInterface
 
     /**
      * @param string[]|null $value
+     * @return $this
      */
     public function setFieldOverride(?array $value): self;
 
+    /**
+     * @return SmartBarInterface
+     */
     public function getSmartBar(): SmartBarInterface;
 
+    /**
+     * @return $this
+     */
     public function setSmartBar(?SmartBarInterface $value): self;
 
+    /**
+     * @return ClientDataInterface
+     */
     public function getClientData(): ClientDataInterface;
 
+    /**
+     * @return $this
+     */
     public function setClientData(?ClientDataInterface $value): self;
 
+    /**
+     * @return string
+     */
     public function getSearchType(): string;
 
+    /**
+     * @return $this
+     */
     public function setSearchType(?string $value): self;
 
+    /**
+     * @return bool
+     */
     public function getIgnoreSpellcheck(): bool;
 
+    /**
+     * @return $this
+     */
     public function setIgnoreSpellcheck(bool $value): self;
 }

--- a/Api/Data/SmartBarInterface.php
+++ b/Api/Data/SmartBarInterface.php
@@ -30,44 +30,104 @@ interface SmartBarInterface
     public const FIELD_KEYWORD_REPLACEMENT = 'KeywordReplacement';
     public const FIELD_PREVIEW_DATE = 'PreviewDate';
 
+    /**
+     * @return bool
+     */
     public function getBoostAndBury(): bool;
 
+    /**
+     * @return $this
+     */
     public function setBoostAndBury(bool $value): self;
 
+    /**
+     * @return bool
+     */
     public function getVisibilityRules(): bool;
 
+    /**
+     * @return $this
+     */
     public function setVisibilityRules(bool $value): self;
 
+    /**
+     * @return bool
+     */
     public function getPersonalizedBoost(): bool;
 
+    /**
+     * @return $this
+     */
     public function setPersonalizedBoost(bool $value): self;
 
+    /**
+     * @return bool
+     */
     public function getPopularityBoost(): bool;
 
+    /**
+     * @return $this
+     */
     public function setPopularityBoost(bool $value): self;
 
+    /**
+     * @return bool
+     */
     public function getItemPin(): bool;
 
+    /**
+     * @return $this
+     */
     public function setItemPin(bool $value): self;
 
+    /**
+     * @return bool
+     */
     public function getPopularitySalesBoost(): bool;
 
+    /**
+     * @return $this
+     */
     public function setPopularitySalesBoost(bool $value): self;
 
+    /**
+     * @return bool
+     */
     public function getPopularityAdd2CartBoost(): bool;
 
+    /**
+     * @return $this
+     */
     public function setPopularityAdd2CartBoost(bool $value): self;
 
+    /**
+     * @return bool
+     */
     public function getPopularityLandingPageBoost(): bool;
 
+    /**
+     * @return $this
+     */
     public function setPopularityLandingPageBoost(bool $value): self;
 
+    /**
+     * @return bool
+     */
     public function getKeywordReplacement(): bool;
 
+    /**
+     * @return $this
+     */
     public function setKeywordReplacement(bool $value): self;
 
+    /**
+     * @return string
+     */
     public function getPreviewDate(): string;
-    
+
+    /**
+     * @return $this
+     */
     public function setPreviewDate(?string $value): self;
 
 }

--- a/Api/Data/VariantOptionsInterface.php
+++ b/Api/Data/VariantOptionsInterface.php
@@ -25,23 +25,53 @@ interface VariantOptionsInterface
     public const FIELD_SORT_CODE = 'SortCode';
     public const FIELD_SORT_BY = 'SortBy';
 
+    /**
+     * @return bool
+     */
     public function getCountFacetHitOnChild(): bool;
 
+    /**
+     * @return $this
+     */
     public function setCountFacetHitOnChild(bool $value): self;
 
+    /**
+     * @return int
+     */
     public function getPageNo(): int;
 
+    /**
+     * @return $this
+     */
     public function setPageNo(int $value): self;
 
+    /**
+     * @return int
+     */
     public function getMaxPerPage(): int;
 
+    /**
+     * @return $this
+     */
     public function setMaxPerPage(int $value): self;
 
+    /**
+     * @return string
+     */
     public function getSortCode(): string;
 
+    /**
+     * @return $this
+     */
     public function setSortCode(?string $value): self;
 
+    /**
+     * @return string
+     */
     public function getSortBy(): string;
 
+    /**
+     * @return $this
+     */
     public function setSortBy(?string $value): self;
 }


### PR DESCRIPTION
| Q             | A
|---------------| ---
| Branch?       | 0.8
| Bug fix?      | yes
| New feature?  | no <!-- please update CHANGELOG-*.md file -->
| Deprecations? | no <!-- please update UPGRADE-*.md and CHANGELOG-*.md files -->
| BC breaks?    | no <!-- please update UPGRADE-*.md and CHANGELOG-*.md files -->
| Tests pass?   | yes
| Tickets       | 

Return back `@return` docblock in `Api\Data` interfaces. `\Magento\Framework\Reflection\TypeProcessor` doesn't allow to have `Api\Data` interfaces without phpDoc annotation. We will overcome it later in https://bridgeline.atlassian.net/browse/HC-1755
