### PR TITLE
fix: update request db field to mediumtext type

### DIFF
--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -45,7 +45,7 @@
         <column xsi:type="int" name="index_id" unsigned="true" nullable="false" comment="Index ID"/>
         <column xsi:type="varchar" name="method" length="255" nullable="true" comment="API action name"/>
         <column xsi:type="tinyint" name="status" default="0" comment="Preload item status (OPEN | COMPLETE | FAILED | REJECTED)"/>
-        <column xsi:type="text" name="request" nullable="false" comment="API Request payload"/>
+        <column xsi:type="mediumtext" name="request" nullable="false" comment="API Request payload"/>
         <constraint xsi:type="primary" referenceId="PRIMARY">
             <column name="id"/>
         </constraint>


### PR DESCRIPTION
| Q             | A
|---------------| ---
| Branch?       | 0.8 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| BC breaks?    | no
| Tests pass?   | yes
| Tickets       | 

`request` field in `hawksearch_data_preload_items` table was too short to contain long requests with lot of attributes