### PR TITLE
fix(indexing): current index is not switched after completing

### DIFF
--- a/Model/DataIndex.php
+++ b/Model/DataIndex.php
@@ -42,14 +42,4 @@ class DataIndex extends AbstractModel
     {
         $this->_init(ResourceModel\DataIndex::class);
     }
-
-    public function beforeSave(): self
-    {
-        if ($this->hasDataChanges()) {
-            $this->setUpdatedAt(null);
-        }
-        return parent::beforeSave();
-    }
-
-
 }

--- a/Model/DataPreloadItems.php
+++ b/Model/DataPreloadItems.php
@@ -17,7 +17,13 @@ namespace HawkSearch\EsIndexing\Model;
 use Magento\Framework\Model\AbstractModel;
 
 /**
+ * @method $this setIndexId(int $value)
+ * @method int getIndexId()
+ * @method $this setMethod(string $value)
  * @method string getMethod()
+ * @method $this setStatus(int $value)
+ * @method int getStatus()
+ * @method $this setRequest(string $value)
  * @method string getRequest()
  */
 class DataPreloadItems extends AbstractModel

--- a/Model/IndexManagement.php
+++ b/Model/IndexManagement.php
@@ -357,9 +357,9 @@ class IndexManagement implements IndexManagementInterface
         /** @var DataIndexCollection $collection */
         $collection = $this->dataIndexCollectionFactory->create()
             ->addFieldToFilter('engine_index_name', $indexName)
-            ->addFieldToFilter('store_id', $this->getStoreId());
+            ->addFieldToFilter('store_id', (string)$this->getStoreId());
 
         /** @var DataIndex */
-        return $collection->getFirstItem();
+        return $collection->getFirstItem()->afterLoad();
     }
 }


### PR DESCRIPTION
When there are concurent consumers hawksearch.indexing and hawksearch.indexing.api_push do updates of the same row in hawksearch_data_index table and it may be possible that lost updates have place

ref: HC-1958, THOM-71

| Q             | A
|---------------| ---
| Branch?       | 0.8 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| BC breaks?    | no
| Tests pass?   | yes
| Tickets       | Fix: HC-1958 Ref: THOM-71
